### PR TITLE
fix: log scenario JSON byte size for diagnostics

### DIFF
--- a/src/Yaat.Client/Services/ServerConnection.cs
+++ b/src/Yaat.Client/Services/ServerConnection.cs
@@ -132,6 +132,8 @@ public sealed class ServerConnection : IAsyncDisposable
     public async Task<LoadScenarioResultDto> LoadScenarioAsync(string scenarioJson)
     {
         EnsureConnected();
+        var byteSize = System.Text.Encoding.UTF8.GetByteCount(scenarioJson);
+        _log.LogInformation("Sending scenario JSON to server ({ByteSize} bytes)", byteSize);
         return await _connection!.InvokeAsync<LoadScenarioResultDto>("LoadScenario", scenarioJson);
     }
 


### PR DESCRIPTION
Closes #2

## Summary
- Logs the UTF-8 byte size of the scenario JSON in `ServerConnection` before sending to the server, making future `MaximumReceiveMessageSize` failures immediately visible in `yaat-client.log`

## Related
The server-side fix (raising `MaximumReceiveMessageSize` from 32KB to 1MB) is in [yaat-server#fix/signalr-scenario-size-limit](https://github.com/leftos/yaat-server/pull/new/fix/signalr-scenario-size-limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)