### PR TITLE
fix: only allow one Flight Plan Editor window at a time

### DIFF
--- a/src/Yaat.Client/ViewModels/MainViewModel.Aircraft.cs
+++ b/src/Yaat.Client/ViewModels/MainViewModel.Aircraft.cs
@@ -1,5 +1,6 @@
 using Yaat.Client.Models;
 using Yaat.Client.Services;
+using Yaat.Client.Views;
 
 namespace Yaat.Client.ViewModels;
 
@@ -88,6 +89,7 @@ public partial class MainViewModel
     {
         Avalonia.Threading.Dispatcher.UIThread.Post(() =>
         {
+            FlightPlanEditorManager.Close();
             var ac = FindAircraft(callsign);
             if (ac is not null)
             {

--- a/src/Yaat.Client/Views/DataGridView.axaml.cs
+++ b/src/Yaat.Client/Views/DataGridView.axaml.cs
@@ -4,7 +4,6 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.VisualTree;
 using Yaat.Client.Models;
-using Yaat.Client.Services;
 using Yaat.Client.ViewModels;
 
 namespace Yaat.Client.Views;
@@ -47,6 +46,7 @@ public partial class DataGridView : UserControl
         if (grid is not null)
         {
             grid.SelectionChanged -= OnGridSelectionChanged;
+            grid.DoubleTapped -= OnGridDoubleTapped;
             grid.ContextRequested -= OnGridContextRequested;
         }
 
@@ -121,7 +121,7 @@ public partial class DataGridView : UserControl
             return;
         }
 
-        OpenFlightPlanEditor(ac, vm, TopLevel.GetTopLevel(this) as Window);
+        FlightPlanEditorManager.Open(ac, vm, TopLevel.GetTopLevel(this) as Window);
     }
 
     private void OnGridContextRequested(object? sender, ContextRequestedEventArgs e)
@@ -154,7 +154,7 @@ public partial class DataGridView : UserControl
 
         menu.Items.Add(new Separator());
         var editItem = new MenuItem { Header = "Edit flight plan" };
-        editItem.Click += (_, _) => OpenFlightPlanEditor(ac, vm, TopLevel.GetTopLevel(this) as Window);
+        editItem.Click += (_, _) => FlightPlanEditorManager.Open(ac, vm, TopLevel.GetTopLevel(this) as Window);
         menu.Items.Add(editItem);
 
         var deleteItem = new MenuItem { Header = "Delete" };
@@ -190,42 +190,5 @@ public partial class DataGridView : UserControl
             }
         };
         menu.Items.Add(textBox);
-    }
-
-    public static void OpenFlightPlanEditor(AircraftModel ac, MainViewModel vm, Window? owner)
-    {
-        var window = new FlightPlanEditorWindow(
-            ac,
-            async (callsign, amendment) =>
-            {
-                var dto = new FlightPlanAmendmentDto(
-                    AircraftType: amendment.AircraftType,
-                    EquipmentSuffix: amendment.EquipmentSuffix,
-                    Departure: amendment.Departure,
-                    Destination: amendment.Destination,
-                    CruiseSpeed: amendment.CruiseSpeed,
-                    CruiseAltitude: amendment.CruiseAltitude,
-                    FlightRules: amendment.FlightRules,
-                    Route: amendment.Route,
-                    Remarks: amendment.Remarks,
-                    Scratchpad1: amendment.Scratchpad1,
-                    Scratchpad2: amendment.Scratchpad2,
-                    BeaconCode: amendment.BeaconCode
-                );
-
-                await vm.Connection.AmendFlightPlanAsync(callsign, dto);
-            }
-        );
-
-        new WindowGeometryHelper(window, vm.Preferences, "FlightPlanEditor", 640, 250).Restore();
-
-        if (owner is not null)
-        {
-            window.Show(owner);
-        }
-        else
-        {
-            window.Show();
-        }
     }
 }

--- a/src/Yaat.Client/Views/FlightPlanEditorManager.cs
+++ b/src/Yaat.Client/Views/FlightPlanEditorManager.cs
@@ -1,0 +1,62 @@
+using Avalonia.Controls;
+using Yaat.Client.Models;
+using Yaat.Client.Services;
+using Yaat.Client.ViewModels;
+
+namespace Yaat.Client.Views;
+
+public static class FlightPlanEditorManager
+{
+    private static FlightPlanEditorWindow? _openEditor;
+
+    public static void Open(AircraftModel ac, MainViewModel vm, Window? owner)
+    {
+        Close();
+
+        var window = new FlightPlanEditorWindow(
+            ac,
+            async (callsign, amendment) =>
+            {
+                var dto = new FlightPlanAmendmentDto(
+                    AircraftType: amendment.AircraftType,
+                    EquipmentSuffix: amendment.EquipmentSuffix,
+                    Departure: amendment.Departure,
+                    Destination: amendment.Destination,
+                    CruiseSpeed: amendment.CruiseSpeed,
+                    CruiseAltitude: amendment.CruiseAltitude,
+                    FlightRules: amendment.FlightRules,
+                    Route: amendment.Route,
+                    Remarks: amendment.Remarks,
+                    Scratchpad1: amendment.Scratchpad1,
+                    Scratchpad2: amendment.Scratchpad2,
+                    BeaconCode: amendment.BeaconCode
+                );
+
+                await vm.Connection.AmendFlightPlanAsync(callsign, dto);
+            }
+        );
+
+        window.Closed += (_, _) => _openEditor = null;
+        _openEditor = window;
+
+        new WindowGeometryHelper(window, vm.Preferences, "FlightPlanEditor", 640, 250).Restore();
+
+        if (owner is not null)
+        {
+            window.Show(owner);
+        }
+        else
+        {
+            window.Show();
+        }
+    }
+
+    public static void Close()
+    {
+        if (_openEditor is not null)
+        {
+            _openEditor.Close();
+            _openEditor = null;
+        }
+    }
+}

--- a/src/Yaat.Client/Views/Ground/GroundView.axaml.cs
+++ b/src/Yaat.Client/Views/Ground/GroundView.axaml.cs
@@ -127,7 +127,7 @@ public partial class GroundView : UserControl
         var ac = mainVm.Aircraft.FirstOrDefault(a => a.Callsign == callsign);
         if (ac is not null)
         {
-            DataGridView.OpenFlightPlanEditor(ac, mainVm, TopLevel.GetTopLevel(this) as Window);
+            FlightPlanEditorManager.Open(ac, mainVm, TopLevel.GetTopLevel(this) as Window);
         }
     }
 

--- a/src/Yaat.Client/Views/Radar/RadarView.ContextMenus.cs
+++ b/src/Yaat.Client/Views/Radar/RadarView.ContextMenus.cs
@@ -38,7 +38,7 @@ public partial class RadarView
         var ac = mainVm.Aircraft.FirstOrDefault(a => a.Callsign == callsign);
         if (ac is not null)
         {
-            DataGridView.OpenFlightPlanEditor(ac, mainVm, TopLevel.GetTopLevel(this) as Window);
+            FlightPlanEditorManager.Open(ac, mainVm, TopLevel.GetTopLevel(this) as Window);
         }
     }
 


### PR DESCRIPTION
## Summary
- Extract FPE window lifecycle into `FlightPlanEditorManager` static class (single-instance enforcement)
- Opening an FPE for any aircraft closes the existing one first, preserving window geometry
- Unsubscribe `DoubleTapped` handler in `OnUnloaded` to prevent handler accumulation on pop-out/dock cycles
- Close FPE when an aircraft is deleted

Closes #19

## Test plan
- [ ] Double-click aircraft in data grid — only one FPE opens
- [ ] Double-click a different aircraft — previous FPE closes, new one opens in same position
- [ ] Open FPE via context menu (data grid, ground view, radar view) — same single-window behavior
- [ ] Delete an aircraft while its FPE is open — FPE closes
- [ ] Pop out data grid and dock it back, then double-click — only one FPE opens (no handler accumulation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)