### PR TITLE
fix: only apply settings when user clicks Save

### DIFF
--- a/src/Yaat.Client/Views/MainWindow.axaml.cs
+++ b/src/Yaat.Client/Views/MainWindow.axaml.cs
@@ -1037,8 +1037,11 @@ public partial class MainWindow : Window
         var dialog = new SettingsWindow(vm.Preferences);
         await dialog.ShowDialog(this);
 
-        vm.RefreshCommandScheme();
-        ApplyKeybinds(vm.Preferences);
+        if ((dialog.DataContext as SettingsViewModel)?.Saved == true)
+        {
+            vm.RefreshCommandScheme();
+            ApplyKeybinds(vm.Preferences);
+        }
     }
 
     private void OnNewWeatherClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)


### PR DESCRIPTION
## Summary
- Gate `RefreshCommandScheme()` and `ApplyKeybinds()` on `SettingsViewModel.Saved == true`
- Previously fired unconditionally after settings dialog closed, including on Cancel
- Server-side defense-in-depth: leftos/yaat-server matching PR adds no-op guards

Closes #20

## Test plan
- [ ] Open settings, change nothing, close — no terminal messages
- [ ] Open settings, change an alias, save — terminal shows updated settings
- [ ] Open settings, change something, cancel — no terminal messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)