### PR TITLE
feat: add search box to aircraft list

### DIFF
--- a/src/Yaat.Client/ViewModels/MainViewModel.cs
+++ b/src/Yaat.Client/ViewModels/MainViewModel.cs
@@ -224,12 +224,43 @@ public partial class MainViewModel : ObservableObject
     public DataGridCollectionView AircraftView { get; }
 
     [ObservableProperty]
+    private string _aircraftFilterText = "";
+
+    partial void OnAircraftFilterTextChanged(string value)
+    {
+        AircraftView.Refresh();
+    }
+
+    [ObservableProperty]
     private bool _showOnlyActiveAircraft;
 
     partial void OnShowOnlyActiveAircraftChanged(bool value)
     {
         _preferences.SetShowOnlyActiveAircraft(value);
         AircraftView.Refresh();
+    }
+
+    private static bool MatchesFilter(AircraftModel ac, string filter)
+    {
+        if (string.IsNullOrEmpty(filter))
+        {
+            return true;
+        }
+
+        return Contains(ac.Callsign, filter)
+            || Contains(ac.AircraftType, filter)
+            || ac.BeaconCode.ToString("D4").Contains(filter, StringComparison.OrdinalIgnoreCase)
+            || Contains(ac.Departure, filter)
+            || Contains(ac.Destination, filter)
+            || Contains(ac.Route, filter)
+            || Contains(ac.AssignedRunway, filter)
+            || Contains(ac.CurrentPhase, filter)
+            || Contains(ac.Scratchpad1, filter)
+            || Contains(ac.Scratchpad2, filter)
+            || Contains(ac.ActiveApproachId, filter)
+            || Contains(ac.OwnerDisplay, filter);
+
+        static bool Contains(string? value, string filter) => value is not null && value.Contains(filter, StringComparison.OrdinalIgnoreCase);
     }
 
     [ObservableProperty]
@@ -265,7 +296,8 @@ public partial class MainViewModel : ObservableObject
     public MainViewModel()
     {
         AircraftView = new DataGridCollectionView(Aircraft);
-        AircraftView.Filter = obj => obj is not AircraftModel ac || !_showOnlyActiveAircraft || !ac.IsDelayed;
+        AircraftView.Filter = obj =>
+            obj is not AircraftModel ac || (!_showOnlyActiveAircraft || !ac.IsDelayed) && MatchesFilter(ac, _aircraftFilterText);
         _showOnlyActiveAircraft = _preferences.ShowOnlyActiveAircraft;
         _showTimelineBar = _preferences.ShowTimelineBar;
         Ground = new GroundViewModel(_connection, SendCommandForViewAsync, OnChildSelectionChanged);

--- a/src/Yaat.Client/Views/DataGridView.axaml
+++ b/src/Yaat.Client/Views/DataGridView.axaml
@@ -4,6 +4,13 @@
              x:Class="Yaat.Client.Views.DataGridView"
              x:DataType="vm:MainViewModel">
 
+    <DockPanel>
+    <TextBox x:Name="SearchBox"
+             DockPanel.Dock="Top"
+             Watermark="Search aircraft (callsign, type, squawk, dep, dest...)"
+             Text="{Binding AircraftFilterText, Mode=TwoWay}"
+             Margin="4,4,4,2"
+             FontSize="12" />
     <DataGrid x:Name="AircraftGrid"
               ItemsSource="{Binding AircraftView}"
               AutoGenerateColumns="False"
@@ -140,5 +147,6 @@
             <DataGridTextColumn Header="Pending Cmds" Binding="{Binding PendingCommands}" Width="Auto" />
         </DataGrid.Columns>
     </DataGrid>
+    </DockPanel>
 
 </UserControl>

--- a/src/Yaat.Client/Views/DataGridView.axaml.cs
+++ b/src/Yaat.Client/Views/DataGridView.axaml.cs
@@ -36,6 +36,12 @@ public partial class DataGridView : UserControl
         grid.DoubleTapped += OnGridDoubleTapped;
         grid.ContextRequested += OnGridContextRequested;
         vm.PropertyChanged += OnViewModelPropertyChanged;
+
+        var searchBox = this.FindControl<TextBox>("SearchBox");
+        if (searchBox is not null)
+        {
+            searchBox.KeyDown += OnSearchBoxKeyDown;
+        }
     }
 
     protected override void OnUnloaded(RoutedEventArgs e)
@@ -50,10 +56,32 @@ public partial class DataGridView : UserControl
             grid.ContextRequested -= OnGridContextRequested;
         }
 
+        var searchBox = this.FindControl<TextBox>("SearchBox");
+        if (searchBox is not null)
+        {
+            searchBox.KeyDown -= OnSearchBoxKeyDown;
+        }
+
         if (DataContext is MainViewModel vm)
         {
             vm.PropertyChanged -= OnViewModelPropertyChanged;
         }
+    }
+
+    private void OnSearchBoxKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key != Key.Escape)
+        {
+            return;
+        }
+
+        if (sender is TextBox textBox)
+        {
+            textBox.Text = "";
+        }
+
+        GetDataGrid()?.Focus();
+        e.Handled = true;
     }
 
     private void OnViewModelPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)


### PR DESCRIPTION
## Summary
- Add `AircraftFilterText` property to MainViewModel with compound filter (search + active/delayed toggle)
- Add search TextBox above DataGrid in DataGridView with watermark text
- Escape key clears filter and moves focus to the grid
- Searches: callsign, type, squawk, dep, dest, route, runway, phase, scratchpad, approach, owner

Closes #15

## Test plan
- [ ] Type in search box — grid filters in real time
- [ ] Search by callsign partial match (e.g. "SWA")
- [ ] Search by squawk code (e.g. "1200")
- [ ] Search by departure/destination airport
- [ ] Press Escape — filter clears, focus returns to grid
- [ ] Pop-out DataGrid window shares the same filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)