### PR TITLE
feat: show flashing handoff indicator in STARS datablock

### DIFF
--- a/src/Yaat.Client/Views/Radar/RadarCanvas.cs
+++ b/src/Yaat.Client/Views/Radar/RadarCanvas.cs
@@ -867,8 +867,8 @@ public sealed class RadarCanvas : MapCanvasBase, IDisposable
         float textW = MathF.Max(w1, w2);
         int lineCount = 2;
 
-        // Owner + scratchpads on same line
-        var line3 = BuildOwnerScratchpadLine(ac.OwnerDisplay, ac.Scratchpad1, ac.Scratchpad2);
+        // Owner + handoff + scratchpads on same line (always include handoff for consistent hit rect)
+        var line3 = BuildOwnerScratchpadLine(ac.OwnerDisplay, ac.HandoffDisplay, ac.Scratchpad1, ac.Scratchpad2);
         if (line3 is not null)
         {
             float w3 = _hitTestPaint.MeasureText(line3);
@@ -1113,21 +1113,27 @@ public sealed class RadarCanvas : MapCanvasBase, IDisposable
         return sorted;
     }
 
-    private static string? BuildOwnerScratchpadLine(string? ownerDisplay, string? sp1, string? sp2)
+    private static string? BuildOwnerScratchpadLine(string? ownerDisplay, string? handoffDisplay, string? sp1, string? sp2)
     {
         bool hasOwner = !string.IsNullOrEmpty(ownerDisplay);
+        bool hasHandoff = !string.IsNullOrEmpty(handoffDisplay);
         bool hasSp1 = !string.IsNullOrEmpty(sp1);
         bool hasSp2 = !string.IsNullOrEmpty(sp2);
 
-        if (!hasOwner && !hasSp1 && !hasSp2)
+        if (!hasOwner && !hasHandoff && !hasSp1 && !hasSp2)
         {
             return null;
         }
 
-        var parts = new List<string>(3);
+        var parts = new List<string>(4);
         if (hasOwner)
         {
-            parts.Add(ownerDisplay!);
+            // Always include handoff for hit-test sizing (no flash)
+            parts.Add(hasHandoff ? $"{ownerDisplay} >{handoffDisplay}" : ownerDisplay!);
+        }
+        else if (hasHandoff)
+        {
+            parts.Add($">{handoffDisplay}");
         }
 
         if (hasSp1)
@@ -1140,7 +1146,7 @@ public sealed class RadarCanvas : MapCanvasBase, IDisposable
             parts.Add($"+{sp2}");
         }
 
-        return string.Join(" ", parts);
+        return parts.Count > 0 ? string.Join(" ", parts) : null;
     }
 
     private static IReadOnlyList<AircraftModel> FilterAircraft(IReadOnlyList<AircraftModel>? aircraft, bool showTopDown)

--- a/src/Yaat.Client/Views/Radar/TargetRenderer.cs
+++ b/src/Yaat.Client/Views/Radar/TargetRenderer.cs
@@ -190,8 +190,8 @@ public sealed class TargetRenderer : IDisposable
             float textW = MathF.Max(w1, w2);
             int lineCount = 2;
 
-            // Line 3: owner TCP + scratchpads on same line
-            string? line3 = BuildOwnerScratchpadLine(ac.OwnerDisplay, ac.Scratchpad1, ac.Scratchpad2);
+            // Line 3: owner TCP + handoff indicator + scratchpads on same line
+            string? line3 = BuildOwnerScratchpadLine(ac.OwnerDisplay, ac.HandoffDisplay, ac.Scratchpad1, ac.Scratchpad2);
             if (line3 is not null)
             {
                 float w3 = _dataBlockPaint.MeasureText(line3);
@@ -226,21 +226,32 @@ public sealed class TargetRenderer : IDisposable
         }
     }
 
-    private static string? BuildOwnerScratchpadLine(string? ownerDisplay, string? sp1, string? sp2)
+    private static string? BuildOwnerScratchpadLine(string? ownerDisplay, string? handoffDisplay, string? sp1, string? sp2)
     {
         bool hasOwner = !string.IsNullOrEmpty(ownerDisplay);
+        bool hasHandoff = !string.IsNullOrEmpty(handoffDisplay);
         bool hasSp1 = !string.IsNullOrEmpty(sp1);
         bool hasSp2 = !string.IsNullOrEmpty(sp2);
 
-        if (!hasOwner && !hasSp1 && !hasSp2)
+        if (!hasOwner && !hasHandoff && !hasSp1 && !hasSp2)
         {
             return null;
         }
 
-        var parts = new List<string>(3);
+        var parts = new List<string>(4);
         if (hasOwner)
         {
-            parts.Add(ownerDisplay!);
+            // Flash handoff indicator: 500ms on/off cycle (all flash in sync, STARS behavior)
+            bool showHandoff = hasHandoff && Environment.TickCount64 / 500 % 2 == 0;
+            parts.Add(showHandoff ? $"{ownerDisplay} >{handoffDisplay}" : ownerDisplay!);
+        }
+        else if (hasHandoff)
+        {
+            bool showHandoff = Environment.TickCount64 / 500 % 2 == 0;
+            if (showHandoff)
+            {
+                parts.Add($">{handoffDisplay}");
+            }
         }
 
         if (hasSp1)
@@ -253,7 +264,7 @@ public sealed class TargetRenderer : IDisposable
             parts.Add($"+{sp2}");
         }
 
-        return string.Join(" ", parts);
+        return parts.Count > 0 ? string.Join(" ", parts) : null;
     }
 
     private static string FormatCwtType(string cwt, string aircraftType)


### PR DESCRIPTION
## Summary
- Display receiving TCP sector code flashing on datablock line 3 during handoff (e.g. `D21 >D31`)
- 500ms on/off flash cycle using wall clock (`Environment.TickCount64`), all indicators flash in sync
- Hit-test rect always uses max width (handoff visible) for consistent click targets
- Minified datablock: handoff suppressed (matches STARS behavior)

Closes #18

## Test plan
- [ ] Initiate handoff (HO command) — receiving sector flashes on datablock
- [ ] Accept handoff — flash stops, owner updates
- [ ] Click datablock during flash — hit target is stable (no size jitter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)