### PR TITLE
feat: show wind and altimeter overlay in ground and radar views

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -972,6 +972,8 @@ An interactive airport surface map showing taxiways, runways, and aircraft posit
 
 The ground layout loads automatically when a scenario is loaded for an airport with ground data.
 
+When weather is loaded, wind direction/speed and altimeter setting are displayed in the top-left corner of the ground view.
+
 ### Radar View
 
 A simplified STARS-style radar display showing aircraft targets, video maps, and navigation fixes. Useful for approach/departure operations.
@@ -995,6 +997,8 @@ A simplified STARS-style radar display showing aircraft targets, video maps, and
 **Right-click context menus:**
 - **On an aircraft**: Heading (fly/present/turn left/turn right), Altitude (common values), Speed, Approach (ILS/RNAV/VIS per runway), Track operations, Delete
 - **On the map** (with aircraft selected): "Fly heading" (computed bearing to click point), "Direct to" (nearest fix within 5nm)
+
+When weather is loaded, wind and altimeter are displayed in the top-left corner of the radar view in STARS green.
 
 **Datablocks** show callsign, altitude, ground speed, and owner. When SP1 or SP2 is set, an additional line displays the scratchpad values.
 

--- a/src/Yaat.Client/ViewModels/GroundViewModel.cs
+++ b/src/Yaat.Client/ViewModels/GroundViewModel.cs
@@ -25,6 +25,9 @@ public partial class GroundViewModel : ObservableObject
     private AircraftModel? _selectedAircraft;
 
     [ObservableProperty]
+    private WeatherDisplayInfo? _weatherInfo;
+
+    [ObservableProperty]
     private TaxiRoute? _activeRoute;
 
     [ObservableProperty]

--- a/src/Yaat.Client/ViewModels/MainViewModel.Weather.cs
+++ b/src/Yaat.Client/ViewModels/MainViewModel.Weather.cs
@@ -7,6 +7,37 @@ using Yaat.Sim;
 
 namespace Yaat.Client.ViewModels;
 
+public record WeatherDisplayInfo(string? StationId, int? WindDirectionDeg, int? WindSpeedKts, int? WindGustKts, double? AltimeterInHg)
+{
+    public string ToDisplayString()
+    {
+        var parts = new List<string>(3);
+
+        if (StationId is not null)
+        {
+            parts.Add(StationId);
+        }
+
+        if (AltimeterInHg is not null)
+        {
+            parts.Add($"{AltimeterInHg:F2}");
+        }
+
+        if (WindDirectionDeg is not null || WindSpeedKts is not null)
+        {
+            var wind = $"{WindDirectionDeg:D3}{WindSpeedKts:D2}";
+            if (WindGustKts is not null)
+            {
+                wind += $"G{WindGustKts:D2}";
+            }
+
+            parts.Add(wind);
+        }
+
+        return string.Join(" ", parts);
+    }
+}
+
 /// <summary>
 /// Weather loading and clearing commands, and the WeatherChanged event handler.
 /// </summary>
@@ -233,6 +264,8 @@ public partial class MainViewModel
             if (dto.Name is null)
             {
                 SetActiveWeatherJson(null);
+                Ground.WeatherInfo = null;
+                Radar.WeatherInfo = null;
             }
             else
             {
@@ -254,7 +287,59 @@ public partial class MainViewModel
                         ?? [],
                 };
                 SetActiveWeatherJson(JsonSerializer.Serialize(profile));
+
+                var allInfo = ExtractAllWeatherDisplay(dto.Metars);
+                Radar.WeatherInfo = allInfo;
+                Ground.WeatherInfo = PickGroundWeather(allInfo, Ground.Layout?.AirportId);
             }
         });
+    }
+
+    private static IReadOnlyList<WeatherDisplayInfo>? ExtractAllWeatherDisplay(IReadOnlyList<string>? metars)
+    {
+        if (metars is null || metars.Count == 0)
+        {
+            return null;
+        }
+
+        var list = new List<WeatherDisplayInfo>(metars.Count);
+        foreach (var raw in metars)
+        {
+            var parsed = MetarParser.Parse(raw);
+            if (parsed is null)
+            {
+                continue;
+            }
+
+            // Strip K prefix for US ICAO stations (KOAK → OAK)
+            var displayId = parsed.StationId;
+            if (displayId?.Length == 4 && displayId.StartsWith('K'))
+            {
+                displayId = displayId[1..];
+            }
+
+            list.Add(new WeatherDisplayInfo(displayId, parsed.WindDirectionDeg, parsed.WindSpeedKts, parsed.WindGustKts, parsed.AltimeterInHg));
+        }
+
+        return list.Count > 0 ? list : null;
+    }
+
+    private static WeatherDisplayInfo? PickGroundWeather(IReadOnlyList<WeatherDisplayInfo>? allInfo, string? airportId)
+    {
+        if (allInfo is null || airportId is null)
+        {
+            return allInfo?.Count > 0 ? allInfo[0] : null;
+        }
+
+        foreach (var info in allInfo)
+        {
+            if (string.Equals(info.StationId, airportId, StringComparison.OrdinalIgnoreCase))
+            {
+                return info;
+            }
+        }
+
+        // Fall back to first station if no match
+        return allInfo.Count > 0 ? allInfo[0] : null;
     }
 }

--- a/src/Yaat.Client/ViewModels/RadarViewModel.cs
+++ b/src/Yaat.Client/ViewModels/RadarViewModel.cs
@@ -82,6 +82,9 @@ public partial class RadarViewModel : ObservableObject
     [ObservableProperty]
     private IReadOnlySet<string>? _programmedFixNames;
 
+    [ObservableProperty]
+    private IReadOnlyList<WeatherDisplayInfo>? _weatherInfo;
+
     private readonly Dictionary<BriteTarget, int> _brightnessValues = new()
     {
         [BriteTarget.Dcb] = 100,

--- a/src/Yaat.Client/Views/Ground/GroundCanvas.cs
+++ b/src/Yaat.Client/Views/Ground/GroundCanvas.cs
@@ -4,6 +4,7 @@ using Avalonia.Input;
 using SkiaSharp;
 using Yaat.Client.Models;
 using Yaat.Client.Services;
+using Yaat.Client.ViewModels;
 using Yaat.Client.Views.Map;
 using Yaat.Sim.Data.Airport;
 
@@ -54,6 +55,10 @@ public sealed class GroundCanvas : MapCanvasBase, IDisposable
     );
 
     public static readonly StyledProperty<bool> ShowDebugInfoProperty = AvaloniaProperty.Register<GroundCanvas, bool>(nameof(ShowDebugInfo));
+
+    public static readonly StyledProperty<WeatherDisplayInfo?> WeatherInfoProperty = AvaloniaProperty.Register<GroundCanvas, WeatherDisplayInfo?>(
+        nameof(WeatherInfo)
+    );
 
     private readonly GroundRenderer _renderer = new();
     private readonly Dictionary<string, SKPoint> _dataBlockOffsets = new();
@@ -120,6 +125,12 @@ public sealed class GroundCanvas : MapCanvasBase, IDisposable
     {
         get => GetValue(ShowDebugInfoProperty);
         set => SetValue(ShowDebugInfoProperty, value);
+    }
+
+    public WeatherDisplayInfo? WeatherInfo
+    {
+        get => GetValue(WeatherInfoProperty);
+        set => SetValue(WeatherInfoProperty, value);
     }
 
     public TaxiRoute? DrawnRoutePreview
@@ -214,7 +225,8 @@ public sealed class GroundCanvas : MapCanvasBase, IDisposable
         double AirportCenterLat,
         double AirportCenterLon,
         double AirportElevation,
-        bool ShowDebugInfo
+        bool ShowDebugInfo,
+        WeatherDisplayInfo? WeatherInfo
     );
 
     protected override object? CreateRenderSnapshot()
@@ -233,7 +245,8 @@ public sealed class GroundCanvas : MapCanvasBase, IDisposable
             AirportCenterLat,
             AirportCenterLon,
             AirportElevation,
-            ShowDebugInfo
+            ShowDebugInfo,
+            WeatherInfo
         );
     }
 
@@ -259,7 +272,8 @@ public sealed class GroundCanvas : MapCanvasBase, IDisposable
             s.AirportCenterLat,
             s.AirportCenterLon,
             s.AirportElevation,
-            s.ShowDebugInfo
+            s.ShowDebugInfo,
+            s.WeatherInfo
         );
     }
 

--- a/src/Yaat.Client/Views/Ground/GroundRenderer.cs
+++ b/src/Yaat.Client/Views/Ground/GroundRenderer.cs
@@ -1,6 +1,7 @@
 using SkiaSharp;
 using Yaat.Client.Models;
 using Yaat.Client.Services;
+using Yaat.Client.ViewModels;
 using Yaat.Client.Views.Map;
 using Yaat.Sim;
 using Yaat.Sim.Data.Airport;
@@ -272,7 +273,8 @@ public sealed class GroundRenderer : IDisposable
         double airportCenterLat = 0,
         double airportCenterLon = 0,
         double airportElevation = 0,
-        bool showDebugInfo = false
+        bool showDebugInfo = false,
+        WeatherDisplayInfo? weatherInfo = null
     )
     {
         canvas.Clear(BackgroundColor);
@@ -293,6 +295,24 @@ public sealed class GroundRenderer : IDisposable
         DrawLabels(canvas);
         DrawAircraft(canvas, vp, aircraft, selectedAircraft, airportCenterLat, airportCenterLon, airportElevation);
         DrawDataBlocks(canvas, vp, aircraft, selectedAircraft, dataBlockOffsets, airportCenterLat, airportCenterLon, airportElevation);
+
+        if (weatherInfo is not null)
+        {
+            DrawWeatherOverlay(canvas, weatherInfo);
+        }
+    }
+
+    private static void DrawWeatherOverlay(SKCanvas canvas, WeatherDisplayInfo info)
+    {
+        using var paint = new SKPaint
+        {
+            Color = new SKColor(0xCC, 0xCC, 0xCC), // light gray
+            TextSize = 14,
+            Typeface = PlatformHelper.MonospaceTypeface,
+            IsAntialias = true,
+        };
+
+        canvas.DrawText(info.ToDisplayString(), 10, 20, paint);
     }
 
     private void DrawRunways(SKCanvas canvas, MapViewport vp, GroundLayoutDto layout)

--- a/src/Yaat.Client/Views/Ground/GroundView.axaml
+++ b/src/Yaat.Client/Views/Ground/GroundView.axaml
@@ -17,7 +17,8 @@
                              AirportCenterLat="{Binding AirportCenterLat}"
                              AirportCenterLon="{Binding AirportCenterLon}"
                              AirportElevation="{Binding AirportElevation}"
-                             Aircraft="{Binding $parent[Window].DataContext.Aircraft}" />
+                             Aircraft="{Binding $parent[Window].DataContext.Aircraft}"
+                             WeatherInfo="{Binding WeatherInfo}" />
 
         <!-- No layout message -->
         <TextBlock Text="No airport layout loaded"

--- a/src/Yaat.Client/Views/Radar/RadarCanvas.cs
+++ b/src/Yaat.Client/Views/Radar/RadarCanvas.cs
@@ -102,6 +102,11 @@ public sealed class RadarCanvas : MapCanvasBase, IDisposable
         IReadOnlyDictionary<int, WaypointCondition>?
     >(nameof(WaypointConditions));
 
+    public static readonly StyledProperty<IReadOnlyList<WeatherDisplayInfo>?> WeatherInfoProperty = AvaloniaProperty.Register<
+        RadarCanvas,
+        IReadOnlyList<WeatherDisplayInfo>?
+    >(nameof(WeatherInfo));
+
     private static readonly SKPoint DefaultDataBlockOffset = new(28, -28);
     private const float DataBlockPad = 3f;
     private const double DragThresholdSq = 25.0; // 5px threshold for click vs drag
@@ -275,6 +280,12 @@ public sealed class RadarCanvas : MapCanvasBase, IDisposable
     {
         get => GetValue(WaypointConditionsProperty);
         set => SetValue(WaypointConditionsProperty, value);
+    }
+
+    public IReadOnlyList<WeatherDisplayInfo>? WeatherInfo
+    {
+        get => GetValue(WeatherInfoProperty);
+        set => SetValue(WeatherInfoProperty, value);
     }
 
     public float BrightnessA
@@ -465,7 +476,8 @@ public sealed class RadarCanvas : MapCanvasBase, IDisposable
         string? RubberBandLabel,
         IReadOnlyDictionary<int, WaypointCondition>? WaypointConditions,
         IReadOnlySet<string> MinifiedCallsigns,
-        bool ShowTopDown
+        bool ShowTopDown,
+        IReadOnlyList<WeatherDisplayInfo>? WeatherInfo
     );
 
     protected override object? CreateRenderSnapshot()
@@ -526,7 +538,8 @@ public sealed class RadarCanvas : MapCanvasBase, IDisposable
             drawRouteCursorLabel,
             IsDrawingRoute ? WaypointConditions : null,
             new HashSet<string>(_minifiedCallsigns),
-            ShowTopDown
+            ShowTopDown,
+            WeatherInfo
         );
     }
 
@@ -587,7 +600,8 @@ public sealed class RadarCanvas : MapCanvasBase, IDisposable
             s.RubberBandLabel,
             s.WaypointConditions,
             s.MinifiedCallsigns,
-            s.ShowTopDown
+            s.ShowTopDown,
+            s.WeatherInfo
         );
     }
 

--- a/src/Yaat.Client/Views/Radar/RadarRenderer.cs
+++ b/src/Yaat.Client/Views/Radar/RadarRenderer.cs
@@ -158,7 +158,8 @@ public sealed class RadarRenderer : IDisposable
         string? rubberBandLabel = null,
         IReadOnlyDictionary<int, WaypointCondition>? waypointConditions = null,
         IReadOnlySet<string>? minifiedCallsigns = null,
-        bool showTopDown = false
+        bool showTopDown = false,
+        IReadOnlyList<WeatherDisplayInfo>? weatherInfo = null
     )
     {
         canvas.Clear(BackgroundColor);
@@ -203,6 +204,31 @@ public sealed class RadarRenderer : IDisposable
         else if (drawRouteOrigin is { } origin && rubberBandTarget is { } target)
         {
             DrawRubberBandFromOrigin(canvas, vp, origin, target, rubberBandLabel);
+        }
+
+        // Weather overlay (top-left)
+        if (weatherInfo is { Count: > 0 })
+        {
+            DrawWeatherOverlay(canvas, weatherInfo);
+        }
+    }
+
+    private static void DrawWeatherOverlay(SKCanvas canvas, IReadOnlyList<WeatherDisplayInfo> stations)
+    {
+        using var paint = new SKPaint
+        {
+            Color = new SKColor(0x00, 0xC8, 0x00), // STARS green
+            TextSize = 14,
+            Typeface = Services.PlatformHelper.MonospaceTypeface,
+            IsAntialias = true,
+        };
+
+        float y = 20;
+        const float lineHeight = 18;
+        foreach (var station in stations)
+        {
+            canvas.DrawText(station.ToDisplayString(), 10, y, paint);
+            y += lineHeight;
         }
     }
 

--- a/src/Yaat.Client/Views/Radar/RadarView.axaml
+++ b/src/Yaat.Client/Views/Radar/RadarView.axaml
@@ -441,7 +441,8 @@
                                ProgrammedFixNames="{Binding ProgrammedFixNames}"
                                IsDrawingRoute="{Binding IsDrawingRoute}"
                                DrawnWaypoints="{Binding DrawnWaypoints}"
-                               WaypointConditions="{Binding WaypointConditionsSnapshot}" />
+                               WaypointConditions="{Binding WaypointConditionsSnapshot}"
+                               WeatherInfo="{Binding WeatherInfo}" />
 
             <!-- MAP popup (shared by GEO MAPS button in Maps submenu) -->
             <Popup x:Name="MapPopup"

--- a/src/Yaat.Sim/MetarParser.cs
+++ b/src/Yaat.Sim/MetarParser.cs
@@ -4,7 +4,15 @@ namespace Yaat.Sim;
 
 public static partial class MetarParser
 {
-    public record ParsedMetar(string StationId, int? CeilingFeetAgl, double? VisibilityStatuteMiles);
+    public record ParsedMetar(
+        string StationId,
+        int? CeilingFeetAgl,
+        double? VisibilityStatuteMiles,
+        int? WindDirectionDeg = null,
+        int? WindSpeedKts = null,
+        int? WindGustKts = null,
+        double? AltimeterInHg = null
+    );
 
     // Visibility patterns: "M1/4SM", "P6SM", "10SM", "3SM", "1/2SM", "1 1/2SM"
     [GeneratedRegex(@"(?<!\S)([PM]?\d+(?:\s+\d+/\d+)?(?:/\d+)?)\s*SM(?!\S)", RegexOptions.Compiled)]
@@ -21,6 +29,14 @@ public static partial class MetarParser
     // Clear sky: CLR or SKC
     [GeneratedRegex(@"\b(CLR|SKC)\b", RegexOptions.Compiled)]
     private static partial Regex ClearSkyRegex();
+
+    // Wind: dddssKT or dddssGggKT or VRBssKT
+    [GeneratedRegex(@"\b(\d{3}|VRB)(\d{2,3})(G(\d{2,3}))?KT\b", RegexOptions.Compiled)]
+    private static partial Regex WindRegex();
+
+    // Altimeter: A followed by 4 digits (e.g., A2992 = 29.92 inHg)
+    [GeneratedRegex(@"\bA(\d{4})\b", RegexOptions.Compiled)]
+    private static partial Regex AltimeterRegex();
 
     public static ParsedMetar? Parse(string? metar)
     {
@@ -58,8 +74,10 @@ public static partial class MetarParser
 
         double? visibility = ParseVisibility(metar);
         int? ceiling = ParseCeiling(metar);
+        var (windDir, windSpd, windGust) = ParseWind(metar);
+        double? altimeter = ParseAltimeter(metar);
 
-        return new ParsedMetar(stationId, ceiling, visibility);
+        return new ParsedMetar(stationId, ceiling, visibility, windDir, windSpd, windGust, altimeter);
     }
 
     public static ParsedMetar? FindStation(IEnumerable<string> metars, string airportId)
@@ -203,5 +221,31 @@ public static partial class MetarParser
         }
 
         return lowestCeiling;
+    }
+
+    private static (int? Direction, int? Speed, int? Gust) ParseWind(string metar)
+    {
+        var match = WindRegex().Match(metar);
+        if (!match.Success)
+        {
+            return (null, null, null);
+        }
+
+        int? direction = match.Groups[1].Value == "VRB" ? null : int.Parse(match.Groups[1].Value);
+        int speed = int.Parse(match.Groups[2].Value);
+        int? gust = match.Groups[4].Success ? int.Parse(match.Groups[4].Value) : null;
+
+        return (direction, speed, gust);
+    }
+
+    private static double? ParseAltimeter(string metar)
+    {
+        var match = AltimeterRegex().Match(metar);
+        if (!match.Success)
+        {
+            return null;
+        }
+
+        return int.Parse(match.Groups[1].Value) / 100.0;
     }
 }

--- a/tests/Yaat.Sim.Tests/MetarParserTests.cs
+++ b/tests/Yaat.Sim.Tests/MetarParserTests.cs
@@ -234,6 +234,52 @@ public class MetarParserTests
         Assert.Equal(600, result.CeilingFeetAgl); // BKN006 = 600ft (lowest BKN/OVC)
     }
 
+    // -------------------------------------------------------------------------
+    // Parse — wind
+    // -------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("KOAK 121853Z 27012KT 10SM CLR 20/12 A2992", 270, 12, null)]
+    [InlineData("KOAK 121853Z 36015G25KT 10SM CLR 20/12 A2992", 360, 15, 25)]
+    [InlineData("KOAK 121853Z VRB05KT 10SM CLR 20/12 A2992", null, 5, null)]
+    [InlineData("KOAK 121853Z 00000KT 10SM CLR 20/12 A2992", 0, 0, null)]
+    public void Parse_Wind_Correct(string metar, int? expectedDir, int? expectedSpd, int? expectedGust)
+    {
+        var result = MetarParser.Parse(metar);
+        Assert.NotNull(result);
+        Assert.Equal(expectedDir, result.WindDirectionDeg);
+        Assert.Equal(expectedSpd, result.WindSpeedKts);
+        Assert.Equal(expectedGust, result.WindGustKts);
+    }
+
+    // -------------------------------------------------------------------------
+    // Parse — altimeter
+    // -------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("KOAK 121853Z 27012KT 10SM CLR 20/12 A2992", 29.92)]
+    [InlineData("KOAK 121853Z 27012KT 10SM CLR 20/12 A3012", 30.12)]
+    [InlineData("KOAK 121853Z 27012KT 10SM CLR 20/12 A2850", 28.50)]
+    public void Parse_Altimeter_Correct(string metar, double expected)
+    {
+        var result = MetarParser.Parse(metar);
+        Assert.NotNull(result);
+        Assert.NotNull(result.AltimeterInHg);
+        Assert.Equal(expected, result.AltimeterInHg!.Value, 2);
+    }
+
+    [Fact]
+    public void Parse_NoAltimeter_ReturnsNull()
+    {
+        var result = MetarParser.Parse("KOAK 121853Z 27012KT 10SM CLR 20/12");
+        Assert.NotNull(result);
+        Assert.Null(result.AltimeterInHg);
+    }
+
+    // -------------------------------------------------------------------------
+    // Real-world METARs — wind + altimeter
+    // -------------------------------------------------------------------------
+
     [Fact]
     public void Parse_RealMetar_MetarPrefix_Handled()
     {


### PR DESCRIPTION
## Summary

- Parse wind direction/speed/gusts and altimeter from METARs in `MetarParser`
- Display weather overlay in ground view (single station matching loaded airport, light gray) and radar view (all stations, STARS green)
- Format: `OAK 29.92 27012` (station, altimeter, wind with optional gusts)
- Wire through `WeatherDisplayInfo` record → ViewModels → StyledProperty → Renderer pipeline

## Test plan

- [x] 8 new MetarParser tests for wind/altimeter parsing
- [x] All 1177 tests pass (1052 Sim + 125 Client)
- [ ] Manual: load weather profile with multiple METARs, verify radar shows all stations
- [ ] Manual: verify ground view shows only the depicted airport's weather
- [ ] Manual: clear weather, verify overlay disappears from both views

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)