### PR TITLE
docs: move CRC connection instructions to user guide

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -162,44 +162,7 @@ You're now ready to create a room and load a scenario. See the [User Guide](USER
 
 ## Step 6: Connect CRC (Optional, Windows Only)
 
-CRC (the VATSIM radar client) is a Windows application. If you want students to connect with [CRC](https://crc.virtualnas.net), you need to tell CRC where your YAAT server is. The YAAT server itself can run on any platform — only CRC needs Windows.
-
-### Option A: Use the Setup Script (Recommended)
-
-The server repo includes a script that configures CRC automatically:
-
-```powershell
-cd C:\dev\yaat-server
-.\Setup-CrcEnvironment.ps1
-```
-
-This finds your CRC installation via the registry and creates or updates its `DevEnvironments.json` file with a "YAAT Local" entry pointing to `http://localhost:5000`.
-
-### Option B: Configure Manually
-
-1. Find your CRC installation folder (check `HKCU:\Software\CRC\Install_Dir` in the registry, or look in `%LOCALAPPDATA%\Programs\crc`)
-2. Create or edit `DevEnvironments.json` in that folder with:
-
-```json
-[
-  {
-    "name": "YAAT Local",
-    "clientHubUrl": "http://localhost:5000/hubs/client",
-    "apiBaseUrl": "http://localhost:5000",
-    "isDisabled": false,
-    "isSweatbox": false
-  }
-]
-```
-
-### Connecting from CRC
-
-1. Make sure the YAAT server is running
-2. Restart CRC (it reads `DevEnvironments.json` on startup)
-3. In CRC's environment selector, choose **YAAT Local**
-4. Connect with your VATSIM credentials — the instructor can then pull you into a room from the YAAT client
-
-See the [User Guide](USER_GUIDE.md#students-panel) for managing CRC clients from the instructor side.
+If you want students to connect with [CRC](https://crc.virtualnas.net), you need to configure CRC to point at your YAAT server. See the [User Guide — Connecting CRC](USER_GUIDE.md#connecting-crc-optional) for setup options and connection instructions.
 
 ## Updating to the Latest Version
 

--- a/README.md
+++ b/README.md
@@ -53,14 +53,7 @@ dotnet run --project src/Yaat.Client
 
 The client connects to `http://localhost:5000` by default.
 
-**CRC setup** (for students connecting via the radar client):
-
-```powershell
-cd path/to/yaat-server
-.\Setup-CrcEnvironment.ps1
-```
-
-This registers the local server in CRC's `DevEnvironments.json`. Restart CRC and select "YAAT Local" from the environment list. See the [installation guide](INSTALL.md) for manual setup or details.
+**CRC setup** (for students connecting via the radar client): see the [User Guide — Connecting CRC](USER_GUIDE.md#connecting-crc-optional) for setup script and manual configuration options.
 
 ## Project Structure
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -9,6 +9,7 @@ YAAT (Yet Another ATC Trainer) is an instructor/RPO desktop client for air traff
   - [Launch](#launch)
   - [Configuration](#configuration)
   - [Connecting](#connecting)
+  - [Connecting CRC (Optional)](#connecting-crc-optional)
   - [Loading a Scenario](#loading-a-scenario)
   - [Unloading a Scenario](#unloading-a-scenario)
   - [Loading a Weather Profile](#loading-a-weather-profile)
@@ -100,6 +101,45 @@ Initials and ARTCC ID are required — you cannot connect without them.
 1. Configure your identity in **Settings** (required)
 2. **File > Connect** (or **Disconnect** to close the connection)
 3. After connecting, the room list appears — create or join a room
+
+### Connecting CRC (Optional)
+
+CRC (Consolidated Radar Client) is the VATSIM radar client that students use to work scopes. Connecting CRC to YAAT is optional — you can use YAAT standalone for command practice.
+
+**Option A: Setup script (recommended)**
+
+The yaat-server repo includes a script that configures CRC automatically:
+
+```powershell
+cd path/to/yaat-server
+.\Setup-CrcEnvironment.ps1
+```
+
+This finds your CRC installation via the registry and creates or updates its `DevEnvironments.json` with a "YAAT Local" entry pointing to `http://localhost:5000`.
+
+**Option B: Manual configuration**
+
+1. Find your CRC installation folder (check `HKCU:\Software\CRC\Install_Dir` in the registry, or look in `%LOCALAPPDATA%\Programs\crc`)
+2. Create or edit `DevEnvironments.json` in that folder:
+
+```json
+[
+  {
+    "name": "YAAT Local",
+    "clientHubUrl": "http://localhost:5000/hubs/client",
+    "apiBaseUrl": "http://localhost:5000",
+    "isDisabled": false,
+    "isSweatbox": false
+  }
+]
+```
+
+**Connecting from CRC:**
+
+1. Make sure the YAAT server is running
+2. Restart CRC (it reads `DevEnvironments.json` on startup)
+3. In CRC's environment selector, choose **YAAT Local**
+4. Connect with your VATSIM credentials — the instructor can then pull the student into a room from the [Students Panel](#students-panel)
 
 ### Loading a Scenario
 
@@ -1052,6 +1092,8 @@ Warning messages appear as gray system entries when the simulator detects potent
 - **Illegal approach intercept**: `Illegal intercept: turned on final 5.2nm from threshold (min 9.0nm) [7110.65 §5-9-1]` — an aircraft was vectored onto the final approach course closer to the runway than the minimum intercept distance derived from the approach gate (FAA 7110.65 §5-9-1). The minimum distance is computed from FAA CIFP data as: approach gate + 2nm, where approach gate = max(FAF distance + 1nm, 5nm). Pattern traffic (base-to-final turns) is exempt.
 
 ## Students Panel
+
+Before students can connect, CRC must be configured to point at your YAAT server — see [Connecting CRC](#connecting-crc-optional) above.
 
 CRC clients (students) connect to the server independently using their own VATSIM CID. If a student's CID doesn't match any YAAT client in a room, their CRC session sits in the "lobby" — connected but not receiving any room data.
 


### PR DESCRIPTION
## Summary

- Move CRC setup instructions from INSTALL.md into USER_GUIDE.md as "Connecting CRC (Optional)" section
- INSTALL.md Step 6 now cross-references the user guide
- README.md CRC blurb now points to user guide
- Students Panel section cross-references CRC setup

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)