### PR TITLE
feat: add label filters for Ground View

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1018,6 +1018,8 @@ An interactive airport surface map showing taxiways, runways, and aircraft posit
 
 The ground layout loads automatically when a scenario is loaded for an airport with ground data.
 
+**Label filters:** A filter bar in the top-right corner lets you toggle visibility for four label categories: **RWY** (runway designators), **TWY** (taxiway names), **HS** (hold-short markers), and **PARK** (parking/spot names). Click a button to toggle that category on or off. When a category is hidden, hovering over the relevant element temporarily shows its label. Filter state is persisted across sessions.
+
 When weather is loaded, wind direction/speed and altimeter setting are displayed in the top-left corner of the ground view.
 
 ### Radar View

--- a/src/Yaat.Client/Services/UserPreferences.cs
+++ b/src/Yaat.Client/Services/UserPreferences.cs
@@ -88,6 +88,10 @@ public sealed class UserPreferences
     public string AircraftSelectKey => _data.AircraftSelectKey;
     public string FocusInputKey => _data.FocusInputKey;
     public HashSet<TerminalEntryKind> HiddenTerminalKinds { get; private set; } = [];
+    public bool GroundShowRunwayLabels => _data.GroundShowRunwayLabels;
+    public bool GroundShowTaxiwayLabels => _data.GroundShowTaxiwayLabels;
+    public bool GroundShowHoldShortLabels => _data.GroundShowHoldShortLabels;
+    public bool GroundShowParkingLabels => _data.GroundShowParkingLabels;
 
     public void SetServerUrl(string url)
     {
@@ -245,6 +249,15 @@ public sealed class UserPreferences
     public void SetFocusInputKey(string key)
     {
         _data.FocusInputKey = key;
+        Save();
+    }
+
+    public void SetGroundLabelFilters(bool runways, bool taxiways, bool holdShorts, bool parking)
+    {
+        _data.GroundShowRunwayLabels = runways;
+        _data.GroundShowTaxiwayLabels = taxiways;
+        _data.GroundShowHoldShortLabels = holdShorts;
+        _data.GroundShowParkingLabels = parking;
         Save();
     }
 
@@ -413,6 +426,10 @@ public sealed class UserPreferences
             AircraftSelectKey = GetFieldOr(obj, "aircraftSelectKey", "Add"),
             FocusInputKey = GetFieldOr(obj, "focusInputKey", "OemTilde"),
             HiddenTerminalKinds = GetFieldOr<List<string>>(obj, "hiddenTerminalKinds", []),
+            GroundShowRunwayLabels = GetFieldOr(obj, "groundShowRunwayLabels", true),
+            GroundShowTaxiwayLabels = GetFieldOr(obj, "groundShowTaxiwayLabels", true),
+            GroundShowHoldShortLabels = GetFieldOr(obj, "groundShowHoldShortLabels", true),
+            GroundShowParkingLabels = GetFieldOr(obj, "groundShowParkingLabels", true),
         };
     }
 
@@ -553,6 +570,10 @@ public sealed class UserPreferences
         public string AircraftSelectKey { get; set; } = "Add";
         public string FocusInputKey { get; set; } = "OemTilde";
         public List<string> HiddenTerminalKinds { get; set; } = [];
+        public bool GroundShowRunwayLabels { get; set; } = true;
+        public bool GroundShowTaxiwayLabels { get; set; } = true;
+        public bool GroundShowHoldShortLabels { get; set; } = true;
+        public bool GroundShowParkingLabels { get; set; } = true;
     }
 
     private sealed class SavedCommandScheme

--- a/src/Yaat.Client/ViewModels/GroundViewModel.cs
+++ b/src/Yaat.Client/ViewModels/GroundViewModel.cs
@@ -18,6 +18,8 @@ public partial class GroundViewModel : ObservableObject
     private AirportGroundLayout? _domainLayout;
     private Func<string, double?>? _getAirportElevation;
 
+    public UserPreferences? Preferences { get; }
+
     [ObservableProperty]
     private GroundLayoutDto? _layout;
 
@@ -54,6 +56,18 @@ public partial class GroundViewModel : ObservableObject
     [ObservableProperty]
     private double _airportElevation;
 
+    [ObservableProperty]
+    private bool _showRunwayLabels = true;
+
+    [ObservableProperty]
+    private bool _showTaxiwayLabels = true;
+
+    [ObservableProperty]
+    private bool _showHoldShortLabels = true;
+
+    [ObservableProperty]
+    private bool _showParkingLabels = true;
+
     private AircraftModel? _drawAircraft;
     private List<int> _drawWaypointIds = [];
     private List<TaxiRoute> _drawSubRoutes = [];
@@ -63,12 +77,22 @@ public partial class GroundViewModel : ObservableObject
     public GroundViewModel(
         ServerConnection connection,
         Func<string, string, string, Task> sendCommand,
-        Action<AircraftModel?>? onSelectionChanged = null
+        Action<AircraftModel?>? onSelectionChanged = null,
+        UserPreferences? preferences = null
     )
     {
         _connection = connection;
         _sendCommand = sendCommand;
         _onSelectionChanged = onSelectionChanged;
+        Preferences = preferences;
+
+        if (preferences is not null)
+        {
+            ShowRunwayLabels = preferences.GroundShowRunwayLabels;
+            ShowTaxiwayLabels = preferences.GroundShowTaxiwayLabels;
+            ShowHoldShortLabels = preferences.GroundShowHoldShortLabels;
+            ShowParkingLabels = preferences.GroundShowParkingLabels;
+        }
     }
 
     public void SetElevationLookup(Func<string, double?> lookup)

--- a/src/Yaat.Client/ViewModels/MainViewModel.cs
+++ b/src/Yaat.Client/ViewModels/MainViewModel.cs
@@ -403,7 +403,7 @@ public partial class MainViewModel : ObservableObject
         _showWarningEntries = !hidden.Contains(TerminalEntryKind.Warning);
         _showErrorEntries = !hidden.Contains(TerminalEntryKind.Error);
         _showChatEntries = !hidden.Contains(TerminalEntryKind.Chat);
-        Ground = new GroundViewModel(_connection, SendCommandForViewAsync, OnChildSelectionChanged);
+        Ground = new GroundViewModel(_connection, SendCommandForViewAsync, OnChildSelectionChanged, _preferences);
         Radar = new RadarViewModel(_connection, _videoMapService, SendCommandForViewAsync, OnChildSelectionChanged);
         Radar.SetPreferences(_preferences);
 

--- a/src/Yaat.Client/Views/Ground/GroundCanvas.cs
+++ b/src/Yaat.Client/Views/Ground/GroundCanvas.cs
@@ -64,6 +64,26 @@ public sealed class GroundCanvas : MapCanvasBase, IDisposable
         nameof(WeatherInfo)
     );
 
+    public static readonly StyledProperty<bool> ShowRunwayLabelsProperty = AvaloniaProperty.Register<GroundCanvas, bool>(
+        nameof(ShowRunwayLabels),
+        defaultValue: true
+    );
+
+    public static readonly StyledProperty<bool> ShowTaxiwayLabelsProperty = AvaloniaProperty.Register<GroundCanvas, bool>(
+        nameof(ShowTaxiwayLabels),
+        defaultValue: true
+    );
+
+    public static readonly StyledProperty<bool> ShowHoldShortLabelsProperty = AvaloniaProperty.Register<GroundCanvas, bool>(
+        nameof(ShowHoldShortLabels),
+        defaultValue: true
+    );
+
+    public static readonly StyledProperty<bool> ShowParkingLabelsProperty = AvaloniaProperty.Register<GroundCanvas, bool>(
+        nameof(ShowParkingLabels),
+        defaultValue: true
+    );
+
     private readonly GroundRenderer _renderer = new();
     private readonly Dictionary<string, SKPoint> _dataBlockOffsets = new();
     private readonly SKPaint _hitTestPaint = new() { TextSize = 12, Typeface = Services.PlatformHelper.MonospaceTypefaceBold };
@@ -135,6 +155,30 @@ public sealed class GroundCanvas : MapCanvasBase, IDisposable
     {
         get => GetValue(WeatherInfoProperty);
         set => SetValue(WeatherInfoProperty, value);
+    }
+
+    public bool ShowRunwayLabels
+    {
+        get => GetValue(ShowRunwayLabelsProperty);
+        set => SetValue(ShowRunwayLabelsProperty, value);
+    }
+
+    public bool ShowTaxiwayLabels
+    {
+        get => GetValue(ShowTaxiwayLabelsProperty);
+        set => SetValue(ShowTaxiwayLabelsProperty, value);
+    }
+
+    public bool ShowHoldShortLabels
+    {
+        get => GetValue(ShowHoldShortLabelsProperty);
+        set => SetValue(ShowHoldShortLabelsProperty, value);
+    }
+
+    public bool ShowParkingLabels
+    {
+        get => GetValue(ShowParkingLabelsProperty);
+        set => SetValue(ShowParkingLabelsProperty, value);
     }
 
     public TaxiRoute? DrawnRoutePreview
@@ -214,6 +258,10 @@ public sealed class GroundCanvas : MapCanvasBase, IDisposable
             || change.Property == DrawHoverPreviewProperty
             || change.Property == DrawWaypointsProperty
             || change.Property == ShowDebugInfoProperty
+            || change.Property == ShowRunwayLabelsProperty
+            || change.Property == ShowTaxiwayLabelsProperty
+            || change.Property == ShowHoldShortLabelsProperty
+            || change.Property == ShowParkingLabelsProperty
         )
         {
             MarkDirty();
@@ -241,7 +289,11 @@ public sealed class GroundCanvas : MapCanvasBase, IDisposable
         double AirportCenterLon,
         double AirportElevation,
         bool ShowDebugInfo,
-        WeatherDisplayInfo? WeatherInfo
+        WeatherDisplayInfo? WeatherInfo,
+        bool ShowRunwayLabels,
+        bool ShowTaxiwayLabels,
+        bool ShowHoldShortLabels,
+        bool ShowParkingLabels
     );
 
     protected override object? CreateRenderSnapshot()
@@ -262,7 +314,11 @@ public sealed class GroundCanvas : MapCanvasBase, IDisposable
             AirportCenterLon,
             AirportElevation,
             ShowDebugInfo,
-            WeatherInfo
+            WeatherInfo,
+            ShowRunwayLabels,
+            ShowTaxiwayLabels,
+            ShowHoldShortLabels,
+            ShowParkingLabels
         );
     }
 
@@ -290,7 +346,11 @@ public sealed class GroundCanvas : MapCanvasBase, IDisposable
             s.AirportCenterLon,
             s.AirportElevation,
             s.ShowDebugInfo,
-            s.WeatherInfo
+            s.WeatherInfo,
+            s.ShowRunwayLabels,
+            s.ShowTaxiwayLabels,
+            s.ShowHoldShortLabels,
+            s.ShowParkingLabels
         );
     }
 

--- a/src/Yaat.Client/Views/Ground/GroundRenderer.cs
+++ b/src/Yaat.Client/Views/Ground/GroundRenderer.cs
@@ -285,7 +285,11 @@ public sealed class GroundRenderer : IDisposable
         double airportCenterLon = 0,
         double airportElevation = 0,
         bool showDebugInfo = false,
-        WeatherDisplayInfo? weatherInfo = null
+        WeatherDisplayInfo? weatherInfo = null,
+        bool showRunwayLabels = true,
+        bool showTaxiwayLabels = true,
+        bool showHoldShortLabels = true,
+        bool showParkingLabels = true
     )
     {
         canvas.Clear(BackgroundColor);
@@ -297,13 +301,13 @@ public sealed class GroundRenderer : IDisposable
 
         _labelCandidates.Clear();
 
-        DrawRunways(canvas, vp, layout);
-        DrawEdges(canvas, vp, layout, showDebugInfo);
+        DrawRunways(canvas, vp, layout, showRunwayLabels);
+        DrawEdges(canvas, vp, layout, showDebugInfo, showTaxiwayLabels, hoveredNodeId);
         DrawActiveRoute(canvas, vp, layout, activeRoute);
         DrawPreviewRoute(canvas, vp, layout, previewRoute);
         DrawDrawnRoute(canvas, vp, layout, drawnRoutePreview, drawWaypoints);
         DrawDrawHoverPreview(canvas, vp, layout, drawHoverPreview);
-        DrawNodes(canvas, vp, layout, hoveredNodeId, showDebugInfo);
+        DrawNodes(canvas, vp, layout, hoveredNodeId, showDebugInfo, showHoldShortLabels, showParkingLabels);
         DrawLabels(canvas);
         DrawAircraft(canvas, vp, aircraft, selectedAircraft, airportCenterLat, airportCenterLon, airportElevation);
         DrawDataBlocks(canvas, vp, aircraft, selectedAircraft, dataBlockOffsets, airportCenterLat, airportCenterLon, airportElevation);
@@ -327,7 +331,7 @@ public sealed class GroundRenderer : IDisposable
         canvas.DrawText(info.ToDisplayString(), 10, 20, paint);
     }
 
-    private void DrawRunways(SKCanvas canvas, MapViewport vp, GroundLayoutDto layout)
+    private void DrawRunways(SKCanvas canvas, MapViewport vp, GroundLayoutDto layout, bool showLabels)
     {
         if (layout.Runways is null)
         {
@@ -382,12 +386,15 @@ public sealed class GroundRenderer : IDisposable
             double midLon = (first[1] + last[1]) / 2.0;
             var (mx, my) = vp.LatLonToScreen(midLat, midLon);
 
-            string label = rwy.Name.Replace(" - ", "/");
-            _labelCandidates.Add(new LabelCandidate(label, mx, my + 4, LabelPriority.Runway, _runwayLabelPaint, null));
+            if (showLabels)
+            {
+                string label = rwy.Name.Replace(" - ", "/");
+                _labelCandidates.Add(new LabelCandidate(label, mx, my + 4, LabelPriority.Runway, _runwayLabelPaint, null));
+            }
         }
     }
 
-    private void DrawEdges(SKCanvas canvas, MapViewport vp, GroundLayoutDto layout, bool showDebugInfo)
+    private void DrawEdges(SKCanvas canvas, MapViewport vp, GroundLayoutDto layout, bool showDebugInfo, bool showTaxiwayLabels, int? hoveredNodeId)
     {
         var nodeScreenPos = new Dictionary<int, (float X, float Y)>(layout.Nodes.Count);
         foreach (var node in layout.Nodes)
@@ -438,23 +445,30 @@ public sealed class GroundRenderer : IDisposable
             }
             else if (!isRunway)
             {
-                var mx = (from.X + to.X) / 2f;
-                var my = (from.Y + to.Y) / 2f;
+                // Show label if taxiway labels are on, or if hovering a connected node (hover-to-show)
+                bool isNearHover =
+                    !showTaxiwayLabels && hoveredNodeId.HasValue && (edge.FromNodeId == hoveredNodeId.Value || edge.ToNodeId == hoveredNodeId.Value);
 
-                // Skip if too close to an existing label for the same taxiway
-                if (IsTaxiLabelTooClose(taxiLabelPositions, edge.TaxiwayName, mx, my))
+                if (showTaxiwayLabels || isNearHover)
                 {
-                    continue;
-                }
+                    var mx = (from.X + to.X) / 2f;
+                    var my = (from.Y + to.Y) / 2f;
 
-                if (!taxiLabelPositions.TryGetValue(edge.TaxiwayName, out var positions))
-                {
-                    positions = [];
-                    taxiLabelPositions[edge.TaxiwayName] = positions;
-                }
+                    // Skip if too close to an existing label for the same taxiway
+                    if (IsTaxiLabelTooClose(taxiLabelPositions, edge.TaxiwayName, mx, my))
+                    {
+                        continue;
+                    }
 
-                positions.Add((mx, my));
-                _labelCandidates.Add(new LabelCandidate(edge.TaxiwayName, mx + 3, my - 3, LabelPriority.Taxiway, _taxiLabelPaint, null));
+                    if (!taxiLabelPositions.TryGetValue(edge.TaxiwayName, out var positions))
+                    {
+                        positions = [];
+                        taxiLabelPositions[edge.TaxiwayName] = positions;
+                    }
+
+                    positions.Add((mx, my));
+                    _labelCandidates.Add(new LabelCandidate(edge.TaxiwayName, mx + 3, my - 3, LabelPriority.Taxiway, _taxiLabelPaint, null));
+                }
             }
         }
     }
@@ -563,7 +577,15 @@ public sealed class GroundRenderer : IDisposable
         }
     }
 
-    private void DrawNodes(SKCanvas canvas, MapViewport vp, GroundLayoutDto layout, int? hoveredNodeId, bool showDebugInfo)
+    private void DrawNodes(
+        SKCanvas canvas,
+        MapViewport vp,
+        GroundLayoutDto layout,
+        int? hoveredNodeId,
+        bool showDebugInfo,
+        bool showHoldShortLabels,
+        bool showParkingLabels
+    )
     {
         foreach (var node in layout.Nodes)
         {
@@ -602,11 +624,17 @@ public sealed class GroundRenderer : IDisposable
             }
             else if (node.Name is not null && node.Type is "Parking" or "Helipad" or "Spot")
             {
-                _labelCandidates.Add(new LabelCandidate(node.Name, sx + 5, sy - 3, LabelPriority.ParkingSpot, _nodeLabelPaint, null));
+                if (showParkingLabels || hoveredNodeId == node.Id)
+                {
+                    _labelCandidates.Add(new LabelCandidate(node.Name, sx + 5, sy - 3, LabelPriority.ParkingSpot, _nodeLabelPaint, null));
+                }
             }
             else if (node.RunwayId is not null && node.Type == "RunwayHoldShort")
             {
-                _labelCandidates.Add(new LabelCandidate($"HS {node.RunwayId}", sx + 5, sy - 3, LabelPriority.HoldShort, _nodeLabelPaint, null));
+                if (showHoldShortLabels || hoveredNodeId == node.Id)
+                {
+                    _labelCandidates.Add(new LabelCandidate($"HS {node.RunwayId}", sx + 5, sy - 3, LabelPriority.HoldShort, _nodeLabelPaint, null));
+                }
             }
 
             if (hoveredNodeId == node.Id)

--- a/src/Yaat.Client/Views/Ground/GroundView.axaml
+++ b/src/Yaat.Client/Views/Ground/GroundView.axaml
@@ -5,6 +5,42 @@
              x:Class="Yaat.Client.Views.Ground.GroundView"
              x:DataType="vm:GroundViewModel">
 
+    <UserControl.Styles>
+        <Style Selector="Button.gnd-filter">
+            <Setter Property="FontFamily" Value="{StaticResource MonoFont}" />
+            <Setter Property="FontSize" Value="11" />
+            <Setter Property="Foreground" Value="#999" />
+            <Setter Property="Background" Value="#22FFFFFF" />
+            <Setter Property="BorderBrush" Value="#444" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="CornerRadius" Value="2" />
+            <Setter Property="Padding" Value="6,2" />
+            <Setter Property="MinWidth" Value="0" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="Template">
+                <ControlTemplate>
+                    <Border Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{TemplateBinding CornerRadius}"
+                            Padding="{TemplateBinding Padding}">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          HorizontalAlignment="Center"
+                                          VerticalAlignment="Center" />
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+        </Style>
+        <Style Selector="Button.gnd-filter:pointerover">
+            <Setter Property="Background" Value="#33FFFFFF" />
+        </Style>
+        <Style Selector="Button.gnd-filter.active">
+            <Setter Property="Background" Value="#44FFFFFF" />
+            <Setter Property="Foreground" Value="#DDD" />
+            <Setter Property="BorderBrush" Value="#888" />
+        </Style>
+    </UserControl.Styles>
+
     <Panel>
         <ground:GroundCanvas x:Name="Canvas"
                              Layout="{Binding Layout}"
@@ -19,7 +55,24 @@
                              AirportCenterLon="{Binding AirportCenterLon}"
                              AirportElevation="{Binding AirportElevation}"
                              Aircraft="{Binding $parent[Window].DataContext.Aircraft}"
-                             WeatherInfo="{Binding WeatherInfo}" />
+                             WeatherInfo="{Binding WeatherInfo}"
+                             ShowRunwayLabels="{Binding ShowRunwayLabels}"
+                             ShowTaxiwayLabels="{Binding ShowTaxiwayLabels}"
+                             ShowHoldShortLabels="{Binding ShowHoldShortLabels}"
+                             ShowParkingLabels="{Binding ShowParkingLabels}" />
+
+        <!-- Label filter bar -->
+        <StackPanel Orientation="Horizontal" Spacing="2"
+                    HorizontalAlignment="Right" VerticalAlignment="Top"
+                    Margin="0,6,6,0"
+                    IsVisible="{Binding Layout, Converter={x:Static ObjectConverters.IsNotNull}}">
+            <TextBlock Text="Labels:" Foreground="#888" FontSize="11" VerticalAlignment="Center" Margin="0,0,4,0"
+                       FontFamily="{StaticResource MonoFont}" />
+            <Button Classes="gnd-filter" Classes.active="{Binding ShowRunwayLabels}" Content="RWY" Click="OnToggleRunwayLabels" />
+            <Button Classes="gnd-filter" Classes.active="{Binding ShowTaxiwayLabels}" Content="TWY" Click="OnToggleTaxiwayLabels" />
+            <Button Classes="gnd-filter" Classes.active="{Binding ShowHoldShortLabels}" Content="HS" Click="OnToggleHoldShortLabels" />
+            <Button Classes="gnd-filter" Classes.active="{Binding ShowParkingLabels}" Content="PARK" Click="OnToggleParkingLabels" />
+        </StackPanel>
 
         <!-- No layout message -->
         <TextBlock Text="No airport layout loaded"

--- a/src/Yaat.Client/Views/Ground/GroundView.axaml.cs
+++ b/src/Yaat.Client/Views/Ground/GroundView.axaml.cs
@@ -104,6 +104,47 @@ public partial class GroundView : UserControl
         }
     }
 
+    private void OnToggleRunwayLabels(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is GroundViewModel vm)
+        {
+            vm.ShowRunwayLabels = !vm.ShowRunwayLabels;
+            SaveLabelFilters(vm);
+        }
+    }
+
+    private void OnToggleTaxiwayLabels(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is GroundViewModel vm)
+        {
+            vm.ShowTaxiwayLabels = !vm.ShowTaxiwayLabels;
+            SaveLabelFilters(vm);
+        }
+    }
+
+    private void OnToggleHoldShortLabels(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is GroundViewModel vm)
+        {
+            vm.ShowHoldShortLabels = !vm.ShowHoldShortLabels;
+            SaveLabelFilters(vm);
+        }
+    }
+
+    private void OnToggleParkingLabels(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is GroundViewModel vm)
+        {
+            vm.ShowParkingLabels = !vm.ShowParkingLabels;
+            SaveLabelFilters(vm);
+        }
+    }
+
+    private static void SaveLabelFilters(GroundViewModel vm)
+    {
+        vm.Preferences?.SetGroundLabelFilters(vm.ShowRunwayLabels, vm.ShowTaxiwayLabels, vm.ShowHoldShortLabels, vm.ShowParkingLabels);
+    }
+
     private void OnAircraftLeftClicked(string callsign)
     {
         if (DataContext is not GroundViewModel vm)

--- a/tests/Yaat.Sim.Tests/NavigationCommandTests.cs
+++ b/tests/Yaat.Sim.Tests/NavigationCommandTests.cs
@@ -513,13 +513,15 @@ public class NavigationCommandTests
                 int fixesReached = prevCount - curCount;
                 for (int j = 0; j < fixesReached; j++)
                 {
-                    passedFixes.Add(passedFixes.Count switch
-                    {
-                        0 => "FIXA",
-                        1 => "FIXB",
-                        2 => "FIXC",
-                        _ => "UNKNOWN",
-                    });
+                    passedFixes.Add(
+                        passedFixes.Count switch
+                        {
+                            0 => "FIXA",
+                            1 => "FIXB",
+                            2 => "FIXC",
+                            _ => "UNKNOWN",
+                        }
+                    );
                 }
 
                 prevCount = curCount;


### PR DESCRIPTION
## Summary
- Adds four toggle buttons (RWY, TWY, HS, PARK) in the top-right corner of the Ground View to control visibility of runway, taxiway, hold-short, and parking/spot labels
- When a label category is hidden, hovering over the relevant node or edge temporarily reveals its label
- Filter state persists across sessions via UserPreferences

## Test plan
- [ ] Load a scenario with ground data; verify all four label types render by default
- [ ] Click each filter button to toggle off; confirm corresponding labels disappear
- [ ] With a category hidden, hover over a node/edge of that type; confirm label appears on hover
- [ ] Restart the app; confirm filter state is restored from preferences

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)