### PR TITLE
feat: Avalonia headless test infrastructure + first wave of tests

### DIFF
--- a/src/Yaat.Client.Core/Logging/AppLog.cs
+++ b/src/Yaat.Client.Core/Logging/AppLog.cs
@@ -16,8 +16,7 @@ public static class AppLog
 
     public static void Initialize()
     {
-        var logDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "yaat");
-        LogPath = Path.Combine(logDir, "yaat-client.log");
+        LogPath = YaatPaths.Combine("yaat-client.log");
 
         var provider = new FileLoggerProvider(LogPath);
 

--- a/src/Yaat.Client.Core/Services/IFilePickerService.cs
+++ b/src/Yaat.Client.Core/Services/IFilePickerService.cs
@@ -1,0 +1,25 @@
+namespace Yaat.Client.Services;
+
+// File-picker abstraction so ViewModels and Windows don't reach into Avalonia's
+// TopLevel.StorageProvider directly. Returns absolute filesystem paths (strings)
+// rather than IStorageFile — every desktop caller already resolves to a local
+// path via TryGetLocalPath() anyway, and strings strip the Avalonia dependency
+// from call sites and tests.
+public interface IFilePickerService
+{
+    Task<string?> OpenFileAsync(OpenFileOptions options);
+
+    Task<IReadOnlyList<string>> OpenFilesAsync(OpenFileOptions options);
+
+    Task<string?> SaveFileAsync(SaveFileOptions options);
+
+    Task<string?> OpenFolderAsync(OpenFolderOptions options);
+}
+
+public sealed record FilePickerFilter(string Name, IReadOnlyList<string> Patterns);
+
+public sealed record OpenFileOptions(string Title, IReadOnlyList<FilePickerFilter> Filters);
+
+public sealed record SaveFileOptions(string Title, string SuggestedFileName, IReadOnlyList<FilePickerFilter> Filters, string DefaultExtension);
+
+public sealed record OpenFolderOptions(string Title);

--- a/src/Yaat.Client.Core/Services/UserPreferences.cs
+++ b/src/Yaat.Client.Core/Services/UserPreferences.cs
@@ -6,6 +6,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using Microsoft.Extensions.Logging;
 using Yaat.Client.Logging;
 using Yaat.Client.Models;
+using Yaat.Sim;
 using Yaat.Sim.Commands;
 
 namespace Yaat.Client.Services;
@@ -31,9 +32,9 @@ public sealed class UserPreferences
 {
     private static readonly ILogger Log = AppLog.CreateLogger<UserPreferences>();
 
-    private static readonly string ConfigDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "yaat");
+    private static readonly string ConfigDir = YaatPaths.AppDataRoot;
 
-    private static readonly string ConfigPath = Path.Combine(ConfigDir, "preferences.json");
+    private static readonly string ConfigPath = YaatPaths.Combine("preferences.json");
 
     internal static readonly JsonSerializerOptions JsonOptions = new()
     {

--- a/src/Yaat.Client/Services/ArtccAirportResolver.cs
+++ b/src/Yaat.Client/Services/ArtccAirportResolver.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Yaat.Client.Logging;
+using Yaat.Sim;
 
 namespace Yaat.Client.Services;
 
@@ -16,12 +17,7 @@ public sealed class ArtccAirportResolver
 
     private static readonly TimeSpan CacheTtl = TimeSpan.FromHours(6);
 
-    private static readonly string CacheDir = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-        "yaat",
-        "cache",
-        "artcc"
-    );
+    private static readonly string CacheDir = YaatPaths.Combine("cache", "artcc");
 
     private readonly ILogger _log = AppLog.CreateLogger<ArtccAirportResolver>();
     private readonly HttpClient _http = new() { Timeout = TimeSpan.FromSeconds(30) };

--- a/src/Yaat.Client/Services/AvaloniaFilePickerService.cs
+++ b/src/Yaat.Client/Services/AvaloniaFilePickerService.cs
@@ -1,0 +1,88 @@
+using Avalonia.Controls;
+using Avalonia.Platform.Storage;
+
+namespace Yaat.Client.Services;
+
+// Production IFilePickerService that delegates to the Avalonia StorageProvider
+// of the given TopLevel (usually a Window). The TopLevel determines which
+// window the picker dialog is modal to, so each Window should construct its
+// own instance rather than share one from MainWindow.
+public sealed class AvaloniaFilePickerService : IFilePickerService
+{
+    private readonly TopLevel _topLevel;
+
+    public AvaloniaFilePickerService(TopLevel topLevel)
+    {
+        _topLevel = topLevel;
+    }
+
+    public async Task<string?> OpenFileAsync(OpenFileOptions options)
+    {
+        var files = await _topLevel.StorageProvider.OpenFilePickerAsync(
+            new FilePickerOpenOptions
+            {
+                Title = options.Title,
+                AllowMultiple = false,
+                FileTypeFilter = ToAvalonia(options.Filters),
+            }
+        );
+
+        return files.Count == 0 ? null : files[0].TryGetLocalPath();
+    }
+
+    public async Task<IReadOnlyList<string>> OpenFilesAsync(OpenFileOptions options)
+    {
+        var files = await _topLevel.StorageProvider.OpenFilePickerAsync(
+            new FilePickerOpenOptions
+            {
+                Title = options.Title,
+                AllowMultiple = true,
+                FileTypeFilter = ToAvalonia(options.Filters),
+            }
+        );
+
+        var paths = new List<string>(files.Count);
+        foreach (var file in files)
+        {
+            var path = file.TryGetLocalPath();
+            if (path is not null)
+            {
+                paths.Add(path);
+            }
+        }
+
+        return paths;
+    }
+
+    public async Task<string?> SaveFileAsync(SaveFileOptions options)
+    {
+        var file = await _topLevel.StorageProvider.SaveFilePickerAsync(
+            new FilePickerSaveOptions
+            {
+                Title = options.Title,
+                SuggestedFileName = options.SuggestedFileName,
+                FileTypeChoices = ToAvalonia(options.Filters),
+                DefaultExtension = options.DefaultExtension,
+            }
+        );
+
+        return file?.TryGetLocalPath();
+    }
+
+    public async Task<string?> OpenFolderAsync(OpenFolderOptions options)
+    {
+        var folders = await _topLevel.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions { Title = options.Title, AllowMultiple = false });
+
+        return folders.Count == 0 ? null : folders[0].TryGetLocalPath();
+    }
+
+    private static List<FilePickerFileType> ToAvalonia(IReadOnlyList<FilePickerFilter> filters)
+    {
+        var result = new List<FilePickerFileType>(filters.Count);
+        foreach (var filter in filters)
+        {
+            result.Add(new FilePickerFileType(filter.Name) { Patterns = filter.Patterns.ToArray() });
+        }
+        return result;
+    }
+}

--- a/src/Yaat.Client/Services/TowerCabImageService.cs
+++ b/src/Yaat.Client/Services/TowerCabImageService.cs
@@ -4,6 +4,7 @@ using MetadataExtractor.Formats.Exif;
 using Microsoft.Extensions.Logging;
 using SkiaSharp;
 using Yaat.Client.Logging;
+using Yaat.Sim;
 using Directory = System.IO.Directory;
 
 namespace Yaat.Client.Services;
@@ -24,12 +25,7 @@ public sealed record TowerCabImage(SKImage Image, double BottomLeftLat, double B
 /// </summary>
 public sealed class TowerCabImageService : IDisposable
 {
-    private static readonly string CacheDir = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-        "yaat",
-        "cache",
-        "towercab"
-    );
+    private static readonly string CacheDir = YaatPaths.Combine("cache", "towercab");
 
     private readonly ILogger _log = AppLog.CreateLogger<TowerCabImageService>();
     private readonly HttpClient _http = new() { Timeout = TimeSpan.FromSeconds(60) };

--- a/src/Yaat.Client/Services/VideoMapService.cs
+++ b/src/Yaat.Client/Services/VideoMapService.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using Yaat.Client.Logging;
+using Yaat.Sim;
 using Yaat.Sim.Data;
 
 namespace Yaat.Client.Services;
@@ -12,12 +13,7 @@ public sealed class VideoMapService
 {
     private const string DataApiBase = "https://data-api.vnas.vatsim.net/Files/VideoMaps";
 
-    private static readonly string CacheDir = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-        "yaat",
-        "cache",
-        "videomaps"
-    );
+    private static readonly string CacheDir = YaatPaths.Combine("cache", "videomaps");
 
     private readonly ILogger _log = AppLog.CreateLogger<VideoMapService>();
 

--- a/src/Yaat.Client/Services/VnasConfigService.cs
+++ b/src/Yaat.Client/Services/VnasConfigService.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Yaat.Client.Logging;
+using Yaat.Sim;
 using Yaat.Sim.Data.Vnas;
 
 namespace Yaat.Client.Services;
@@ -14,12 +15,7 @@ public sealed class VnasConfigService : IDisposable
 {
     private const string ConfigUrl = "https://configuration.vnas.vatsim.net/";
 
-    private static readonly string CachePath = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-        "yaat",
-        "cache",
-        "vnas-config.json"
-    );
+    private static readonly string CachePath = YaatPaths.Combine("cache", "vnas-config.json");
 
     private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 

--- a/src/Yaat.Client/ViewModels/GroundViewModel.cs
+++ b/src/Yaat.Client/ViewModels/GroundViewModel.cs
@@ -274,13 +274,7 @@ public partial class GroundViewModel : ObservableObject
 
     private static async Task<TowerCabMapData?> DownloadAndParseTowerCabMapAsync(string videoMapBaseUrl, string artccId, string videoMapId)
     {
-        var cacheDir = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "yaat",
-            "cache",
-            "towercab-maps",
-            artccId
-        );
+        var cacheDir = YaatPaths.Combine("cache", "towercab-maps", artccId);
         Directory.CreateDirectory(cacheDir);
         var cachePath = Path.Combine(cacheDir, $"{videoMapId}.geojson");
 

--- a/src/Yaat.Client/ViewModels/MainViewModel.Timeline.cs
+++ b/src/Yaat.Client/ViewModels/MainViewModel.Timeline.cs
@@ -1,6 +1,5 @@
 using System.IO;
 using System.IO.Compression;
-using Avalonia.Platform.Storage;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Extensions.Logging;
 using Yaat.Client.Logging;
@@ -148,33 +147,21 @@ public partial class MainViewModel
                 return;
             }
 
-            var window = Avalonia.Application.Current?.ApplicationLifetime
-                is Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime desktop
-                ? desktop.MainWindow
-                : null;
-
-            if (window is null)
-            {
-                return;
-            }
-
-            var file = await window.StorageProvider.SaveFilePickerAsync(
-                new FilePickerSaveOptions
-                {
-                    Title = "Save Recording",
-                    DefaultExtension = "yaat-recording.zip",
-                    FileTypeChoices = [new FilePickerFileType("YAAT Recording") { Patterns = ["*.yaat-recording.zip", "*.yaat-recording.br"] }],
-                    SuggestedFileName = $"{SanitizeFileName(ActiveScenarioName ?? "recording")}.yaat-recording.zip",
-                }
+            var path = await _filePicker.SaveFileAsync(
+                new SaveFileOptions(
+                    Title: "Save Recording",
+                    SuggestedFileName: $"{SanitizeFileName(ActiveScenarioName ?? "recording")}.yaat-recording.zip",
+                    Filters: [new FilePickerFilter("YAAT Recording", ["*.yaat-recording.zip", "*.yaat-recording.br"])],
+                    DefaultExtension: "yaat-recording.zip"
+                )
             );
 
-            if (file is null)
+            if (path is null)
             {
                 return;
             }
 
-            await using var stream = await file.OpenWriteAsync();
-            await stream.WriteAsync(compressedBytes);
+            await File.WriteAllBytesAsync(path, compressedBytes);
 
             StatusText = "Recording saved";
         }
@@ -231,32 +218,21 @@ public partial class MainViewModel
                 return;
             }
 
-            var window = Avalonia.Application.Current?.ApplicationLifetime
-                is Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime desktop
-                ? desktop.MainWindow
-                : null;
-
-            if (window is null)
-            {
-                return;
-            }
-
-            var file = await window.StorageProvider.SaveFilePickerAsync(
-                new FilePickerSaveOptions
-                {
-                    Title = "Save Bug Report Bundle",
-                    DefaultExtension = "yaat-bug-report-bundle.zip",
-                    FileTypeChoices = [new FilePickerFileType("YAAT Bug Report Bundle") { Patterns = ["*.yaat-bug-report-bundle.zip"] }],
-                    SuggestedFileName = $"{SanitizeFileName(ActiveScenarioName ?? "recording")}.yaat-bug-report-bundle.zip",
-                }
+            var path = await _filePicker.SaveFileAsync(
+                new SaveFileOptions(
+                    Title: "Save Bug Report Bundle",
+                    SuggestedFileName: $"{SanitizeFileName(ActiveScenarioName ?? "recording")}.yaat-bug-report-bundle.zip",
+                    Filters: [new FilePickerFilter("YAAT Bug Report Bundle", ["*.yaat-bug-report-bundle.zip"])],
+                    DefaultExtension: "yaat-bug-report-bundle.zip"
+                )
             );
 
-            if (file is null)
+            if (path is null)
             {
                 return;
             }
 
-            await using var stream = await file.OpenWriteAsync();
+            await using var stream = File.Create(path);
             using var archive = new ZipArchive(stream, ZipArchiveMode.Create);
 
             using var recordingStream = new MemoryStream(compressedBytes);
@@ -337,40 +313,19 @@ public partial class MainViewModel
     {
         try
         {
-            var window = Avalonia.Application.Current?.ApplicationLifetime
-                is Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime desktop
-                ? desktop.MainWindow
-                : null;
-
-            if (window is null)
-            {
-                return;
-            }
-
-            var files = await window.StorageProvider.OpenFilePickerAsync(
-                new FilePickerOpenOptions
-                {
-                    Title = "Load Recording",
-                    AllowMultiple = false,
-                    FileTypeFilter =
-                    [
-                        new FilePickerFileType("YAAT Recording")
-                        {
-                            Patterns = ["*.yaat-recording.zip", "*.yaat-recording.br", "*.yaat-recording.json"],
-                        },
-                    ],
-                }
+            var path = await _filePicker.OpenFileAsync(
+                new OpenFileOptions(
+                    Title: "Load Recording",
+                    Filters: [new FilePickerFilter("YAAT Recording", ["*.yaat-recording.zip", "*.yaat-recording.br", "*.yaat-recording.json"])]
+                )
             );
 
-            if (files.Count == 0)
+            if (path is null)
             {
                 return;
             }
 
-            await using var stream = await files[0].OpenReadAsync();
-            using var memStream = new MemoryStream();
-            await stream.CopyToAsync(memStream);
-            var recordingBytes = memStream.ToArray();
+            var recordingBytes = await File.ReadAllBytesAsync(path);
 
             StatusText = "Loading recording...";
             var result = await _connection.LoadRecordingAsync(recordingBytes);

--- a/src/Yaat.Client/ViewModels/MainViewModel.Weather.cs
+++ b/src/Yaat.Client/ViewModels/MainViewModel.Weather.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using Avalonia.Platform.Storage;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Extensions.Logging;
 using Yaat.Client.Services;
@@ -197,33 +196,16 @@ public partial class MainViewModel
             return;
         }
 
-        var mainWindow = Avalonia.Application.Current?.ApplicationLifetime
-            is Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime desktop
-            ? desktop.MainWindow
-            : null;
-
-        if (mainWindow?.StorageProvider is not { } storageProvider)
-        {
-            return;
-        }
-
         var sanitized = SanitizeFileName(ActiveWeatherName ?? "weather");
-        var file = await storageProvider.SaveFilePickerAsync(
-            new FilePickerSaveOptions
-            {
-                Title = "Save Weather As…",
-                SuggestedFileName = sanitized,
-                FileTypeChoices = [new FilePickerFileType("JSON") { Patterns = ["*.json"] }],
-                DefaultExtension = "json",
-            }
+        var path = await _filePicker.SaveFileAsync(
+            new SaveFileOptions(
+                Title: "Save Weather As…",
+                SuggestedFileName: sanitized,
+                Filters: [new FilePickerFilter("JSON", ["*.json"])],
+                DefaultExtension: "json"
+            )
         );
 
-        if (file is null)
-        {
-            return;
-        }
-
-        var path = file.TryGetLocalPath();
         if (path is null)
         {
             return;

--- a/src/Yaat.Client/ViewModels/MainViewModel.cs
+++ b/src/Yaat.Client/ViewModels/MainViewModel.cs
@@ -25,6 +25,7 @@ public partial class MainViewModel : ObservableObject
     public ServerConnection Connection => _connection;
     private readonly UserPreferences _preferences = new();
     private readonly CommandInputController _commandInput = new();
+    private readonly IFilePickerService _filePicker;
     private readonly VideoMapService _videoMapService = new();
     private readonly VnasConfigService _vnasConfigService = new();
     private readonly TowerCabImageService _towerCabImageService = new();
@@ -641,8 +642,9 @@ public partial class MainViewModel : ObservableObject
         IsSpeechEnabled = _preferences.SpeechEnabled;
     }
 
-    public MainViewModel()
+    public MainViewModel(IFilePickerService filePicker)
     {
+        _filePicker = filePicker;
         _isSpeechEnabled = _preferences.SpeechEnabled;
 
         // Speech pipeline wiring. The order here matters: LlmService must exist before

--- a/src/Yaat.Client/Views/ColumnChooserWindow.axaml.cs
+++ b/src/Yaat.Client/Views/ColumnChooserWindow.axaml.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Text.Json;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
-using Avalonia.Platform.Storage;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Yaat.Client.Services;
 
@@ -13,12 +12,13 @@ namespace Yaat.Client.Views;
 
 public partial class ColumnChooserWindow : Window
 {
-    private static readonly FilePickerFileType GridLayoutFileType = new("YAAT Grid Layout") { Patterns = ["*.yaat-grid-layout.json"] };
+    private static readonly FilePickerFilter GridLayoutFileType = new("YAAT Grid Layout", ["*.yaat-grid-layout.json"]);
 
     private readonly Dictionary<string, double>? _columnWidths;
     private readonly string? _sortColumn;
     private readonly ListSortDirection? _sortDirection;
     private readonly List<string> _defaultOrder;
+    private readonly IFilePickerService _filePicker;
 
     public ObservableCollection<ColumnEntry> Entries { get; } = [];
     public bool Confirmed { get; private set; }
@@ -29,6 +29,7 @@ public partial class ColumnChooserWindow : Window
     {
         InitializeComponent();
         _defaultOrder = [];
+        _filePicker = new AvaloniaFilePickerService(this);
     }
 
     public ColumnChooserWindow(
@@ -41,6 +42,7 @@ public partial class ColumnChooserWindow : Window
     )
     {
         InitializeComponent();
+        _filePicker = new AvaloniaFilePickerService(this);
 
         _columnWidths = columnWidths;
         _sortColumn = sortColumn;
@@ -208,36 +210,28 @@ public partial class ColumnChooserWindow : Window
             SortDirection = _sortDirection,
         };
 
-        var file = await StorageProvider.SaveFilePickerAsync(
-            new FilePickerSaveOptions
-            {
-                Title = "Export Grid Layout",
-                SuggestedFileName = "layout.yaat-grid-layout.json",
-                FileTypeChoices = [GridLayoutFileType],
-            }
+        var path = await _filePicker.SaveFileAsync(
+            new SaveFileOptions(
+                Title: "Export Grid Layout",
+                SuggestedFileName: "layout.yaat-grid-layout.json",
+                Filters: [GridLayoutFileType],
+                DefaultExtension: "yaat-grid-layout.json"
+            )
         );
 
-        if (file is null)
+        if (path is null)
         {
             return;
         }
 
-        await using var stream = await file.OpenWriteAsync();
+        await using var stream = File.Create(path);
         await JsonSerializer.SerializeAsync(stream, layout, UserPreferences.JsonOptions);
     }
 
     private async void OnImport(object? sender, RoutedEventArgs e)
     {
-        var files = await StorageProvider.OpenFilePickerAsync(
-            new FilePickerOpenOptions
-            {
-                Title = "Import Grid Layout",
-                AllowMultiple = false,
-                FileTypeFilter = [GridLayoutFileType],
-            }
-        );
-
-        if (files.Count == 0)
+        var path = await _filePicker.OpenFileAsync(new OpenFileOptions("Import Grid Layout", [GridLayoutFileType]));
+        if (path is null)
         {
             return;
         }
@@ -245,7 +239,7 @@ public partial class ColumnChooserWindow : Window
         SavedGridLayout? layout;
         try
         {
-            await using var stream = await files[0].OpenReadAsync();
+            await using var stream = File.OpenRead(path);
             layout = await JsonSerializer.DeserializeAsync<SavedGridLayout>(stream, UserPreferences.JsonOptions);
         }
         catch (JsonException)

--- a/src/Yaat.Client/Views/LoadScenarioWindow.axaml.cs
+++ b/src/Yaat.Client/Views/LoadScenarioWindow.axaml.cs
@@ -2,7 +2,6 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using Avalonia.Controls;
 using Avalonia.Input;
-using Avalonia.Platform.Storage;
 using Microsoft.Extensions.Logging;
 using Yaat.Client.Logging;
 using Yaat.Client.Services;
@@ -22,6 +21,7 @@ public partial class LoadScenarioWindow : Window
     private readonly UserPreferences _preferences;
     private readonly TrainingDataService _trainingData = new();
     private readonly string _artccId;
+    private readonly IFilePickerService _filePicker;
 
     // ARTCC tab state
     private readonly ComboBox _artccFacilityFilter;
@@ -49,6 +49,7 @@ public partial class LoadScenarioWindow : Window
         _preferences = preferences;
         _artccId = preferences.ArtccId;
         InitializeComponent();
+        _filePicker = new AvaloniaFilePickerService(this);
         new WindowGeometryHelper(this, preferences, "LoadScenario", 600, 500).Restore();
 
         _sourceTabs = this.FindControl<TabControl>("SourceTabs")!;
@@ -155,17 +156,10 @@ public partial class LoadScenarioWindow : Window
 
     private async void OnBrowseClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
     {
-        var folders = await StorageProvider.OpenFolderPickerAsync(
-            new FolderPickerOpenOptions { Title = "Select Scenario Folder", AllowMultiple = false }
-        );
-
-        if (folders.Count > 0)
+        var path = await _filePicker.OpenFolderAsync(new OpenFolderOptions("Select Scenario Folder"));
+        if (path is not null)
         {
-            var path = folders[0].TryGetLocalPath();
-            if (path is not null)
-            {
-                ScanFolder(path);
-            }
+            ScanFolder(path);
         }
     }
 

--- a/src/Yaat.Client/Views/LoadWeatherWindow.axaml.cs
+++ b/src/Yaat.Client/Views/LoadWeatherWindow.axaml.cs
@@ -1,7 +1,6 @@
 using System.Text.Json;
 using Avalonia.Controls;
 using Avalonia.Input;
-using Avalonia.Platform.Storage;
 using Microsoft.Extensions.Logging;
 using Yaat.Client.Logging;
 using Yaat.Client.Services;
@@ -20,6 +19,7 @@ public partial class LoadWeatherWindow : Window
     private readonly UserPreferences _preferences;
     private readonly TrainingDataService _trainingData = new();
     private readonly string _artccId;
+    private readonly IFilePickerService _filePicker;
 
     // ARTCC tab state
     private readonly TextBlock _artccStatusText;
@@ -43,6 +43,7 @@ public partial class LoadWeatherWindow : Window
         _preferences = preferences;
         _artccId = preferences.ArtccId;
         InitializeComponent();
+        _filePicker = new AvaloniaFilePickerService(this);
         new WindowGeometryHelper(this, preferences, "LoadWeather", 550, 450).Restore();
 
         _sourceTabs = this.FindControl<TabControl>("SourceTabs")!;
@@ -110,17 +111,10 @@ public partial class LoadWeatherWindow : Window
 
     private async void OnBrowseClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
     {
-        var folders = await StorageProvider.OpenFolderPickerAsync(
-            new FolderPickerOpenOptions { Title = "Select Weather Folder", AllowMultiple = false }
-        );
-
-        if (folders.Count > 0)
+        var path = await _filePicker.OpenFolderAsync(new OpenFolderOptions("Select Weather Folder"));
+        if (path is not null)
         {
-            var path = folders[0].TryGetLocalPath();
-            if (path is not null)
-            {
-                ScanFolder(path);
-            }
+            ScanFolder(path);
         }
     }
 

--- a/src/Yaat.Client/Views/MainWindow.axaml.cs
+++ b/src/Yaat.Client/Views/MainWindow.axaml.cs
@@ -37,7 +37,7 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
-        var vm = new MainViewModel();
+        var vm = new MainViewModel(new AvaloniaFilePickerService(this));
         DataContext = vm;
 
         _geometryHelper = new WindowGeometryHelper(this, vm.Preferences, "Main", 1200, 700);

--- a/src/Yaat.Client/Views/MainWindow.axaml.cs
+++ b/src/Yaat.Client/Views/MainWindow.axaml.cs
@@ -28,6 +28,14 @@ public partial class MainWindow : Window
     private GroundViewWindow? _groundViewWindow;
     private RadarViewWindow? _radarViewWindow;
     private WeatherTimelineEditorWindow? _weatherEditorWindow;
+
+    // Test hooks — read-only views of the subordinate windows the MainWindow creates
+    // in response to IsDataGridPoppedOut / IsGroundViewPoppedOut / IsRadarViewPoppedOut
+    // flipping. Not used in production; present so headless lifecycle tests can assert
+    // a pop-out actually spawned a window.
+    internal DataGridWindow? DataGridWindow => _dataGridWindow;
+    internal GroundViewWindow? GroundViewWindow => _groundViewWindow;
+    internal RadarViewWindow? RadarViewWindow => _radarViewWindow;
     private bool _restoringGrid;
     private bool _isConfirmedClose;
     private bool _isMainWindowClosing;
@@ -1006,6 +1014,9 @@ public partial class MainWindow : Window
     // representation; exactly one is shown at a time, flipped by entry.IsPoppedOut.
     private readonly Dictionary<VStripsDockEntryViewModel, TabItem> _stripsTabItems = [];
     private readonly Dictionary<VStripsDockEntryViewModel, VStripsViewWindow> _stripsWindows = [];
+
+    // Test hook — see note on DataGridWindow/GroundViewWindow/RadarViewWindow above.
+    internal IReadOnlyDictionary<VStripsDockEntryViewModel, VStripsViewWindow> StripsWindows => _stripsWindows;
 
     private void WireStripsEntryWindows(MainViewModel vm)
     {

--- a/src/Yaat.Client/Views/SettingsWindow.axaml.cs
+++ b/src/Yaat.Client/Views/SettingsWindow.axaml.cs
@@ -1,7 +1,6 @@
 using System.Text.Json;
 using Avalonia.Controls;
 using Avalonia.Input;
-using Avalonia.Platform.Storage;
 using Yaat.Client.Services;
 using Yaat.Client.ViewModels;
 
@@ -9,13 +8,11 @@ namespace Yaat.Client.Views;
 
 public partial class SettingsWindow : Window
 {
-    private static readonly FilePickerFileType MacroFileType = new("YAAT Macros")
-    {
-        Patterns = ["*.yaat-macros.json"],
-        MimeTypes = ["application/json"],
-    };
+    private static readonly FilePickerFilter MacroFileType = new("YAAT Macros", ["*.yaat-macros.json"]);
 
-    private static readonly FilePickerFileType JsonFileType = new("JSON Files") { Patterns = ["*.json"], MimeTypes = ["application/json"] };
+    private static readonly FilePickerFilter JsonFileType = new("JSON Files", ["*.json"]);
+
+    private readonly IFilePickerService _filePicker;
 
     public SettingsWindow()
         : this(new UserPreferences(), audioCapture: null) { }
@@ -26,6 +23,7 @@ public partial class SettingsWindow : Window
     public SettingsWindow(UserPreferences preferences, AudioCaptureService? audioCapture)
     {
         InitializeComponent();
+        _filePicker = new AvaloniaFilePickerService(this);
 
         var vm = new SettingsViewModel(preferences, audioCapture);
         DataContext = vm;
@@ -82,21 +80,7 @@ public partial class SettingsWindow : Window
             return;
         }
 
-        var files = await StorageProvider.OpenFilePickerAsync(
-            new FilePickerOpenOptions
-            {
-                Title = "Select LLM Model File (GGUF)",
-                AllowMultiple = false,
-                FileTypeFilter = [new FilePickerFileType("GGUF Models") { Patterns = ["*.gguf"] }],
-            }
-        );
-
-        if (files.Count == 0)
-        {
-            return;
-        }
-
-        var path = files[0].TryGetLocalPath();
+        var path = await _filePicker.OpenFileAsync(new OpenFileOptions("Select LLM Model File (GGUF)", [new FilePickerFilter("GGUF Models", ["*.gguf"])]));
         if (!string.IsNullOrEmpty(path))
         {
             vm.LlmModelPath = path;
@@ -125,23 +109,15 @@ public partial class SettingsWindow : Window
             return;
         }
 
-        var files = await StorageProvider.OpenFilePickerAsync(
-            new FilePickerOpenOptions
-            {
-                Title = "Import Macros",
-                AllowMultiple = false,
-                FileTypeFilter = [MacroFileType, JsonFileType],
-            }
-        );
-
-        if (files.Count == 0)
+        var path = await _filePicker.OpenFileAsync(new OpenFileOptions("Import Macros", [MacroFileType, JsonFileType]));
+        if (path is null)
         {
             return;
         }
 
         try
         {
-            await using var stream = await files[0].OpenReadAsync();
+            await using var stream = File.OpenRead(path);
             var macros = await JsonSerializer.DeserializeAsync<List<SavedMacro>>(stream, UserPreferences.JsonOptions);
             if (macros is null || macros.Count == 0)
             {
@@ -279,21 +255,21 @@ public partial class SettingsWindow : Window
 
     private async Task ExportMacrosAsync(List<SavedMacro> macros)
     {
-        var file = await StorageProvider.SaveFilePickerAsync(
-            new FilePickerSaveOptions
-            {
-                Title = "Export Macros",
-                SuggestedFileName = "macros.yaat-macros.json",
-                FileTypeChoices = [MacroFileType, JsonFileType],
-            }
+        var path = await _filePicker.SaveFileAsync(
+            new SaveFileOptions(
+                Title: "Export Macros",
+                SuggestedFileName: "macros.yaat-macros.json",
+                Filters: [MacroFileType, JsonFileType],
+                DefaultExtension: "yaat-macros.json"
+            )
         );
 
-        if (file is null)
+        if (path is null)
         {
             return;
         }
 
-        await using var stream = await file.OpenWriteAsync();
+        await using var stream = File.Create(path);
         await JsonSerializer.SerializeAsync(stream, macros, UserPreferences.JsonOptions);
     }
 }

--- a/src/Yaat.Client/Views/WeatherTimelineEditorWindow.axaml.cs
+++ b/src/Yaat.Client/Views/WeatherTimelineEditorWindow.axaml.cs
@@ -1,5 +1,4 @@
 using Avalonia.Controls;
-using Avalonia.Platform.Storage;
 using Microsoft.Extensions.Logging;
 using Yaat.Client.Logging;
 using Yaat.Client.Services;
@@ -12,6 +11,7 @@ public partial class WeatherTimelineEditorWindow : Window
     private static readonly ILogger Log = AppLog.CreateLogger<WeatherTimelineEditorWindow>();
 
     private readonly Func<string, string, Task>? _applyCallback;
+    private readonly IFilePickerService _filePicker;
 
     public WeatherTimelineEditorWindow()
         : this(WeatherTimelineEditorViewModel.CreateEmpty(""), new UserPreferences(), null) { }
@@ -25,6 +25,7 @@ public partial class WeatherTimelineEditorWindow : Window
         _applyCallback = applyCallback;
         DataContext = viewModel;
         InitializeComponent();
+        _filePicker = new AvaloniaFilePickerService(this);
         new WindowGeometryHelper(this, preferences, "WeatherTimelineEditor", 800, 600).Restore();
 
         this.FindControl<Button>("ApplyButton")!.Click += OnApplyClick;
@@ -58,22 +59,15 @@ public partial class WeatherTimelineEditorWindow : Window
             return;
         }
 
-        var file = await StorageProvider.SaveFilePickerAsync(
-            new FilePickerSaveOptions
-            {
-                Title = "Save Weather As…",
-                SuggestedFileName = string.IsNullOrWhiteSpace(vm.Name) ? "weather" : vm.Name,
-                FileTypeChoices = [new FilePickerFileType("JSON") { Patterns = ["*.json"] }],
-                DefaultExtension = "json",
-            }
+        var path = await _filePicker.SaveFileAsync(
+            new SaveFileOptions(
+                Title: "Save Weather As…",
+                SuggestedFileName: string.IsNullOrWhiteSpace(vm.Name) ? "weather" : vm.Name,
+                Filters: [new FilePickerFilter("JSON", ["*.json"])],
+                DefaultExtension: "json"
+            )
         );
 
-        if (file is null)
-        {
-            return;
-        }
-
-        var path = file.TryGetLocalPath();
         if (path is null)
         {
             return;

--- a/src/Yaat.Client/Yaat.Client.csproj
+++ b/src/Yaat.Client/Yaat.Client.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Yaat.Client.Tests" />
+    <InternalsVisibleTo Include="Yaat.Client.UI.Tests" />
     <InternalsVisibleTo Include="Yaat.SpeechSandbox" />
   </ItemGroup>
 

--- a/src/Yaat.Sim/Data/Faa/FaaAircraftDataService.cs
+++ b/src/Yaat.Sim/Data/Faa/FaaAircraftDataService.cs
@@ -26,8 +26,7 @@ public sealed class FaaAircraftDataService : IDisposable
     {
         _http = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
 
-        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        _cacheDir = Path.Combine(localAppData, "yaat", "cache", "faa-acd");
+        _cacheDir = YaatPaths.Combine("cache", "faa-acd");
     }
 
     public async Task InitializeAsync()

--- a/src/Yaat.Sim/Data/Vnas/CifpDataService.cs
+++ b/src/Yaat.Sim/Data/Vnas/CifpDataService.cs
@@ -27,8 +27,7 @@ public sealed class CifpDataService : IDisposable
     {
         _http = new HttpClient { Timeout = TimeSpan.FromSeconds(60) };
 
-        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        _cacheDir = Path.Combine(localAppData, "yaat", "cache", "cifp");
+        _cacheDir = YaatPaths.Combine("cache", "cifp");
     }
 
     public async Task InitializeAsync()

--- a/src/Yaat.Sim/Data/Vnas/VnasDataService.cs
+++ b/src/Yaat.Sim/Data/Vnas/VnasDataService.cs
@@ -33,8 +33,7 @@ public sealed class VnasDataService : IDisposable
     {
         _http = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
 
-        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        _cacheDir = Path.Combine(localAppData, "yaat", "cache");
+        _cacheDir = YaatPaths.Combine("cache");
     }
 
     public async Task InitializeAsync()

--- a/src/Yaat.Sim/Testing/TestVnasData.cs
+++ b/src/Yaat.Sim/Testing/TestVnasData.cs
@@ -100,8 +100,7 @@ public static class TestVnasData
         }
 
         // Fall back to system CIFP cache
-        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        var cacheDir = Path.Combine(localAppData, "yaat", "cache", "cifp");
+        var cacheDir = YaatPaths.Combine("cache", "cifp");
         if (!Directory.Exists(cacheDir))
         {
             return null;

--- a/src/Yaat.Sim/YaatPaths.cs
+++ b/src/Yaat.Sim/YaatPaths.cs
@@ -1,0 +1,19 @@
+namespace Yaat.Sim;
+
+// Central resolver for the YAAT per-user data directory. Every call site that
+// previously did Path.Combine(LocalApplicationData, "yaat", ...) must go through
+// this helper so tests can redirect the base dir via the YAAT_APPDATA_DIR env var
+// without touching the user's real %LOCALAPPDATA%/yaat folder.
+public static class YaatPaths
+{
+    public static string AppDataRoot { get; } =
+        Environment.GetEnvironmentVariable("YAAT_APPDATA_DIR") ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "yaat");
+
+    public static string Combine(params string[] parts)
+    {
+        var all = new string[parts.Length + 1];
+        all[0] = AppDataRoot;
+        Array.Copy(parts, 0, all, 1, parts.Length);
+        return Path.Combine(all);
+    }
+}

--- a/tests/Yaat.Client.UI.Tests/Fakes/FakeFilePickerService.cs
+++ b/tests/Yaat.Client.UI.Tests/Fakes/FakeFilePickerService.cs
@@ -1,0 +1,66 @@
+using Yaat.Client.Services;
+
+namespace Yaat.Client.UI.Tests.Fakes;
+
+// Test double: each call pops the next queued response, so tests can script a
+// sequence of pick/save/cancel outcomes. Every call is logged so assertions can
+// verify the options passed by production code.
+internal sealed class FakeFilePickerService : IFilePickerService
+{
+    private readonly Queue<object?> _responses = new();
+
+    public List<RecordedCall> Calls { get; } = [];
+
+    public void QueueOpenFile(string? path) => _responses.Enqueue(path);
+
+    public void QueueOpenFiles(IReadOnlyList<string> paths) => _responses.Enqueue(paths);
+
+    public void QueueSaveFile(string? path) => _responses.Enqueue(path);
+
+    public void QueueOpenFolder(string? path) => _responses.Enqueue(path);
+
+    public Task<string?> OpenFileAsync(OpenFileOptions options)
+    {
+        Calls.Add(new RecordedCall(PickerKind.OpenFile, options.Title, options));
+        return Task.FromResult(DequeueOrDefault<string?>());
+    }
+
+    public Task<IReadOnlyList<string>> OpenFilesAsync(OpenFileOptions options)
+    {
+        Calls.Add(new RecordedCall(PickerKind.OpenFiles, options.Title, options));
+        return Task.FromResult(DequeueOrDefault<IReadOnlyList<string>?>() ?? []);
+    }
+
+    public Task<string?> SaveFileAsync(SaveFileOptions options)
+    {
+        Calls.Add(new RecordedCall(PickerKind.SaveFile, options.Title, options));
+        return Task.FromResult(DequeueOrDefault<string?>());
+    }
+
+    public Task<string?> OpenFolderAsync(OpenFolderOptions options)
+    {
+        Calls.Add(new RecordedCall(PickerKind.OpenFolder, options.Title, options));
+        return Task.FromResult(DequeueOrDefault<string?>());
+    }
+
+    private T? DequeueOrDefault<T>()
+    {
+        if (_responses.Count == 0)
+        {
+            return default;
+        }
+
+        var next = _responses.Dequeue();
+        return next is T typed ? typed : default;
+    }
+}
+
+internal enum PickerKind
+{
+    OpenFile,
+    OpenFiles,
+    SaveFile,
+    OpenFolder,
+}
+
+internal sealed record RecordedCall(PickerKind Kind, string Title, object Options);

--- a/tests/Yaat.Client.UI.Tests/Helpers/HeadlessWindowExtensions.cs
+++ b/tests/Yaat.Client.UI.Tests/Helpers/HeadlessWindowExtensions.cs
@@ -1,0 +1,49 @@
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Input;
+using Avalonia.Threading;
+
+namespace Yaat.Client.UI.Tests.Helpers;
+
+internal static class HeadlessWindowExtensions
+{
+    public static void ShowAndRunLayout(this Window window)
+    {
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        // Trigger a layout pass so controls wire their OnLoaded handlers (CommandInputView
+        // attaches its KeyDown handlers in OnLoaded, so this must run before we simulate
+        // keyboard input).
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    public static void PumpDispatcher()
+    {
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    public static void DispatchKey(this Window window, Key key, RawInputModifiers modifiers = RawInputModifiers.None)
+    {
+        window.KeyPressQwerty(ToPhysicalKey(key), modifiers);
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    // Headless KeyPressQwerty takes a PhysicalKey. Map the common logical keys we simulate
+    // in tests; extend as tests grow rather than up-front (per the zero-speculation rule).
+    private static PhysicalKey ToPhysicalKey(Key key) =>
+        key switch
+        {
+            Key.Enter => PhysicalKey.Enter,
+            Key.Tab => PhysicalKey.Tab,
+            Key.Escape => PhysicalKey.Escape,
+            Key.Up => PhysicalKey.ArrowUp,
+            Key.Down => PhysicalKey.ArrowDown,
+            Key.Left => PhysicalKey.ArrowLeft,
+            Key.Right => PhysicalKey.ArrowRight,
+            Key.Space => PhysicalKey.Space,
+            Key.Back => PhysicalKey.Backspace,
+            Key.Add => PhysicalKey.NumPadAdd,
+            _ => throw new System.ArgumentOutOfRangeException(nameof(key), key, "Add mapping in HeadlessWindowExtensions.ToPhysicalKey"),
+        };
+}

--- a/tests/Yaat.Client.UI.Tests/ModuleInit.cs
+++ b/tests/Yaat.Client.UI.Tests/ModuleInit.cs
@@ -1,0 +1,22 @@
+using System.Runtime.CompilerServices;
+
+namespace Yaat.Client.UI.Tests;
+
+// Runs when the test assembly loads, before xUnit reflects TestAppBuilder and
+// before any YAAT static that reads YaatPaths.AppDataRoot. Redirects every
+// path YAAT derives from %LOCALAPPDATA%/yaat to a unique temp folder so tests
+// never touch the developer's real prefs, logs, or vNAS cache.
+//
+// The folder is not cleaned up on exit — inspect .tmp/... after a run if a
+// test misbehaves. Each test process gets a fresh Guid-keyed dir so stale
+// state cannot leak between runs.
+internal static class ModuleInit
+{
+    [ModuleInitializer]
+    public static void Initialize()
+    {
+        var testDir = Path.Combine(Path.GetTempPath(), "yaat-ui-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(testDir);
+        Environment.SetEnvironmentVariable("YAAT_APPDATA_DIR", testDir);
+    }
+}

--- a/tests/Yaat.Client.UI.Tests/SmokeTests.cs
+++ b/tests/Yaat.Client.UI.Tests/SmokeTests.cs
@@ -2,6 +2,7 @@ using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Xunit;
 using Yaat.Client.UI.Tests.Helpers;
+using Yaat.Sim;
 
 namespace Yaat.Client.UI.Tests;
 
@@ -9,6 +10,16 @@ namespace Yaat.Client.UI.Tests;
 // fonts, etc.) this file fails first, before any of the richer tests run.
 public class SmokeTests
 {
+    [Fact]
+    public void YaatPaths_RedirectedToTempDir()
+    {
+        // Fails loudly if ModuleInit didn't run before YaatPaths.AppDataRoot was
+        // initialized — we must never write to the real %LOCALAPPDATA%/yaat.
+        Assert.DoesNotContain("AppData\\Local\\yaat", YaatPaths.AppDataRoot);
+        Assert.DoesNotContain("AppData/Local/yaat", YaatPaths.AppDataRoot);
+        Assert.Contains("yaat-ui-tests", YaatPaths.AppDataRoot);
+    }
+
     [AvaloniaFact]
     public void HeadlessLifetime_BootsWindow()
     {

--- a/tests/Yaat.Client.UI.Tests/SmokeTests.cs
+++ b/tests/Yaat.Client.UI.Tests/SmokeTests.cs
@@ -1,0 +1,29 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Xunit;
+using Yaat.Client.UI.Tests.Helpers;
+
+namespace Yaat.Client.UI.Tests;
+
+// Canary for the headless lifetime: if Avalonia can't bootstrap our App (themes,
+// fonts, etc.) this file fails first, before any of the richer tests run.
+public class SmokeTests
+{
+    [AvaloniaFact]
+    public void HeadlessLifetime_BootsWindow()
+    {
+        var probe = new TextBlock { Text = "hello" };
+        var window = new Window
+        {
+            Width = 400,
+            Height = 300,
+            Content = probe,
+        };
+
+        window.ShowAndRunLayout();
+
+        Assert.True(window.IsVisible);
+        Assert.Equal("hello", probe.Text);
+        Assert.True(probe.Bounds.Width > 0, "layout pass should have run");
+    }
+}

--- a/tests/Yaat.Client.UI.Tests/TestAppBuilder.cs
+++ b/tests/Yaat.Client.UI.Tests/TestAppBuilder.cs
@@ -1,5 +1,6 @@
 using Avalonia;
 using Avalonia.Headless;
+using Velopack;
 using Yaat.Client;
 using Yaat.Client.UI.Tests;
 
@@ -15,6 +16,19 @@ namespace Yaat.Client.UI.Tests;
 // and custom draw ops work without SkiaSharp GPU backends.
 public static class TestAppBuilder
 {
-    public static AppBuilder BuildAvaloniaApp() =>
-        AppBuilder.Configure<App>().UseHeadless(new AvaloniaHeadlessPlatformOptions { UseHeadlessDrawing = true }).WithInterFont();
+    private static int _velopackInitialized;
+
+    public static AppBuilder BuildAvaloniaApp()
+    {
+        // MainViewModel constructs UpdateService eagerly, which requires the
+        // VelopackLocator to be initialized. VelopackApp.Build().Run() is idempotent
+        // in test context (no install hook args), so doing it here lets the real VM
+        // construct without patching production code.
+        if (Interlocked.CompareExchange(ref _velopackInitialized, 1, 0) == 0)
+        {
+            VelopackApp.Build().Run();
+        }
+
+        return AppBuilder.Configure<App>().UseHeadless(new AvaloniaHeadlessPlatformOptions { UseHeadlessDrawing = true }).WithInterFont();
+    }
 }

--- a/tests/Yaat.Client.UI.Tests/TestAppBuilder.cs
+++ b/tests/Yaat.Client.UI.Tests/TestAppBuilder.cs
@@ -1,0 +1,20 @@
+using Avalonia;
+using Avalonia.Headless;
+using Yaat.Client;
+using Yaat.Client.UI.Tests;
+
+[assembly: AvaloniaTestApplication(typeof(TestAppBuilder))]
+
+namespace Yaat.Client.UI.Tests;
+
+// Hosts the real Yaat.Client.App under a headless Avalonia platform so UI tests run
+// in CI without a display/GPU. Reuses Program.BuildAvaloniaApp? No: Program's builder
+// calls UsePlatformDetect() which would try to start a real windowing subsystem.
+// Instead we replicate the same App+fonts config and swap UsePlatformDetect for
+// UseHeadless. UseHeadlessDrawing=true picks the software renderer so Window.Show()
+// and custom draw ops work without SkiaSharp GPU backends.
+public static class TestAppBuilder
+{
+    public static AppBuilder BuildAvaloniaApp() =>
+        AppBuilder.Configure<App>().UseHeadless(new AvaloniaHeadlessPlatformOptions { UseHeadlessDrawing = true }).WithInterFont();
+}

--- a/tests/Yaat.Client.UI.Tests/Views/CommandInputViewTests.cs
+++ b/tests/Yaat.Client.UI.Tests/Views/CommandInputViewTests.cs
@@ -1,0 +1,113 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Yaat.Client.Models;
+using Yaat.Client.UI.Tests.Fakes;
+using Yaat.Client.UI.Tests.Helpers;
+using Yaat.Client.ViewModels;
+using Yaat.Client.Views;
+using Xunit;
+
+namespace Yaat.Client.UI.Tests.Views;
+
+// Widget-level coverage for CommandInputView.axaml.cs — specifically the KeyDown
+// handler wired in OnLoaded (lines 85-199) that unit-level CommandInputController
+// tests can't reach because the handler lives in code-behind.
+public class CommandInputViewTests
+{
+    [AvaloniaFact]
+    public void Escape_WithNoPopup_ClearsCommandTextAndSelection()
+    {
+        var (window, view, vm) = SetupInputView();
+        vm.CommandText = "abc";
+
+        var textBox = FindCommandInput(view);
+        textBox.Focus();
+        Helpers.HeadlessWindowExtensions.PumpDispatcher();
+
+        window.DispatchKey(Key.Escape);
+
+        Assert.Equal("", vm.CommandText);
+        Assert.Null(vm.SelectedAircraft);
+    }
+
+    [AvaloniaFact]
+    public void Up_WithNoPopup_WalksHistoryBackwards()
+    {
+        var (window, view, vm) = SetupInputView();
+        // Populate history (CommandHistory is ObservableCollection<string>, newest at index 0)
+        vm.CommandHistory.Insert(0, "OLDER");
+        vm.CommandHistory.Insert(0, "NEWER");
+
+        var textBox = FindCommandInput(view);
+        textBox.Focus();
+        Helpers.HeadlessWindowExtensions.PumpDispatcher();
+
+        window.DispatchKey(Key.Up);
+        Assert.Equal("NEWER", vm.CommandText);
+
+        window.DispatchKey(Key.Up);
+        Assert.Equal("OLDER", vm.CommandText);
+    }
+
+    [AvaloniaFact]
+    public void AircraftSelectKey_ResolvesCallsignAndClearsInput()
+    {
+        var (window, view, vm) = SetupInputView();
+        vm.Aircraft.Add(new AircraftModel { Callsign = "UAL123" });
+        // Default aircraft-select keybind is Key.Add (NumPad +) with no modifiers.
+        vm.CommandText = "UAL";
+
+        var textBox = FindCommandInput(view);
+        textBox.Focus();
+        Helpers.HeadlessWindowExtensions.PumpDispatcher();
+
+        window.DispatchKey(Key.Add);
+
+        Assert.NotNull(vm.SelectedAircraft);
+        Assert.Equal("UAL123", vm.SelectedAircraft!.Callsign);
+        Assert.Equal("", vm.CommandText);
+    }
+
+    [AvaloniaFact]
+    public void Escape_WithSignatureHelpVisible_OnlyDismissesSignatureHelp()
+    {
+        var (window, view, vm) = SetupInputView();
+        vm.CommandText = "typed";
+        // SignatureHelpState exposes IsVisible as an ObservableProperty, so we can
+        // flip it directly without building a full CommandSignatureSet just to test
+        // that the Escape branch in CommandInputView preserves CommandText while
+        // SignatureHelp is open.
+        vm.CommandInput.SignatureHelp.IsVisible = true;
+
+        var textBox = FindCommandInput(view);
+        textBox.Focus();
+        Helpers.HeadlessWindowExtensions.PumpDispatcher();
+
+        window.DispatchKey(Key.Escape);
+
+        Assert.False(vm.CommandInput.SignatureHelp.IsVisible);
+        Assert.Equal("typed", vm.CommandText);
+    }
+
+    private static (Window window, CommandInputView view, MainViewModel vm) SetupInputView()
+    {
+        var vm = new MainViewModel(new FakeFilePickerService());
+        var view = new CommandInputView { DataContext = vm };
+        var window = new Window
+        {
+            Width = 600,
+            Height = 200,
+            Content = view,
+        };
+        window.ShowAndRunLayout();
+        return (window, view, vm);
+    }
+
+    private static TextBox FindCommandInput(CommandInputView view)
+    {
+        var textBox = view.FindControl<TextBox>("CommandInput");
+        Assert.NotNull(textBox);
+        return textBox!;
+    }
+}

--- a/tests/Yaat.Client.UI.Tests/Views/MainWindowLifecycleTests.cs
+++ b/tests/Yaat.Client.UI.Tests/Views/MainWindowLifecycleTests.cs
@@ -1,0 +1,138 @@
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Yaat.Client.ViewModels;
+using Yaat.Client.Views;
+using Xunit;
+
+namespace Yaat.Client.UI.Tests.Views;
+
+// Coverage for the MainWindow <-> MainViewModel observable-driven window
+// lifecycle (recent commits 04cdd67/f30f6b3/c85a6e2/7f9dd7c — per-facility
+// strips, collapse-when-all-popped-out).
+public class MainWindowLifecycleTests
+{
+    [AvaloniaFact]
+    public void MainWindow_BootsInHeadless()
+    {
+        var window = new MainWindow();
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(window.IsVisible);
+        Assert.IsType<MainViewModel>(window.DataContext);
+    }
+
+    [AvaloniaFact]
+    public void DataGridPopOut_CreatesAndClosesSubordinateWindow()
+    {
+        var (main, vm) = BootMainWindow();
+        // Start from a known docked state — ignores whatever the user's saved
+        // UserPreferences say about the initial pop-out state.
+        vm.IsDataGridPoppedOut = false;
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Null(main.DataGridWindow);
+
+        vm.IsDataGridPoppedOut = true;
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.NotNull(main.DataGridWindow);
+        Assert.True(main.DataGridWindow!.IsVisible);
+
+        vm.IsDataGridPoppedOut = false;
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Null(main.DataGridWindow);
+    }
+
+    [AvaloniaFact]
+    public void GroundAndRadarPopOut_EachCreatesItsOwnWindow()
+    {
+        var (main, vm) = BootMainWindow();
+        vm.IsGroundViewPoppedOut = false;
+        vm.IsRadarViewPoppedOut = false;
+        Dispatcher.UIThread.RunJobs();
+
+        vm.IsGroundViewPoppedOut = true;
+        vm.IsRadarViewPoppedOut = true;
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.NotNull(main.GroundViewWindow);
+        Assert.NotNull(main.RadarViewWindow);
+        Assert.True(main.GroundViewWindow!.IsVisible);
+        Assert.True(main.RadarViewWindow!.IsVisible);
+
+        vm.IsGroundViewPoppedOut = false;
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Null(main.GroundViewWindow);
+        Assert.NotNull(main.RadarViewWindow); // other window untouched
+    }
+
+    [AvaloniaFact]
+    public void AllTabsPoppedOut_CollapsesContentGrid()
+    {
+        var (_, vm) = BootMainWindow();
+        // Normalise initial state (ignore user's prefs).
+        vm.IsDataGridPoppedOut = false;
+        vm.IsGroundViewPoppedOut = false;
+        vm.IsRadarViewPoppedOut = false;
+        vm.StripsEntries[0].IsPoppedOut = false;
+        vm.IsTerminalDocked = true;
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.True(vm.IsAnyTabVisible);
+        Assert.True(vm.IsContentGridVisible);
+
+        vm.IsDataGridPoppedOut = true;
+        vm.IsGroundViewPoppedOut = true;
+        vm.IsRadarViewPoppedOut = true;
+        // Student strips entry is index 0 and must also be popped out for the
+        // "every tab popped out" collapse case (commit f30f6b3).
+        vm.StripsEntries[0].IsPoppedOut = true;
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.False(vm.IsAnyTabVisible);
+        // Terminal is still docked, so the content grid remains visible overall.
+        Assert.True(vm.IsContentGridVisible);
+
+        // Undocking the terminal collapses the entire content grid — menu bar only.
+        vm.IsTerminalDocked = false;
+        Dispatcher.UIThread.RunJobs();
+        Assert.False(vm.IsContentGridVisible);
+    }
+
+    [AvaloniaFact]
+    public void StripsEntry_PopOut_CreatesFacilityWindow()
+    {
+        var (main, vm) = BootMainWindow();
+        var studentEntry = vm.StripsEntries[0];
+        studentEntry.IsPoppedOut = false;
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Empty(main.StripsWindows);
+
+        studentEntry.IsPoppedOut = true;
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Single(main.StripsWindows);
+        Assert.True(main.StripsWindows[studentEntry].IsVisible);
+
+        studentEntry.IsPoppedOut = false;
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Empty(main.StripsWindows);
+    }
+
+    private static (MainWindow main, MainViewModel vm) BootMainWindow()
+    {
+        var main = new MainWindow();
+        main.Show();
+        Dispatcher.UIThread.RunJobs();
+        main.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+        return (main, (MainViewModel)main.DataContext!);
+    }
+}

--- a/tests/Yaat.Client.UI.Tests/Views/VStripsViewInteractionTests.cs
+++ b/tests/Yaat.Client.UI.Tests/Views/VStripsViewInteractionTests.cs
@@ -1,0 +1,123 @@
+using Avalonia.Controls;
+using Avalonia.Controls.Presenters;
+using Avalonia.Headless.XUnit;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Yaat.Client.Services;
+using Yaat.Client.ViewModels;
+using Yaat.Client.Views.VStrips;
+using Xunit;
+
+namespace Yaat.Client.UI.Tests.Views;
+
+// View-layer coverage for VStripsView interactions that can't be reached from
+// pure VStripsViewModel tests (see tests/Yaat.Client.Tests/VStripsViewModelTests.cs).
+// Every user action funnels through VStripsViewModel helpers and emits a canonical
+// command string, which tests capture via the sendCommand delegate.
+public class VStripsViewInteractionTests
+{
+    [AvaloniaFact]
+    public void VStripsViewWindow_BootsWithSeededBays()
+    {
+        var (vm, _) = MakeVm();
+        SeedBays(vm, SimpleConfig());
+        var (window, view) = BootView(vm);
+
+        Assert.True(window.IsVisible);
+        Assert.Equal("Fresno ATCT", vm.FacilityName);
+        Assert.Equal(2, vm.Bays.Count);
+
+        // ItemsControl realizes a Button per bay — find at least one to prove
+        // the DataTemplate and Tag binding survive the headless layout pass.
+        var bayButtons = view.GetVisualDescendants().OfType<Button>().Where(b => b.Tag is StripBayViewModel).ToList();
+        Assert.Equal(2, bayButtons.Count);
+    }
+
+    [AvaloniaFact]
+    public void BayButtonClick_SelectsBayViaViewModel()
+    {
+        var (vm, captured) = MakeVm();
+        SeedBays(vm, SimpleConfig());
+        var (_, view) = BootView(vm);
+
+        // Click the LOCAL bay (second one). SelectBayAsync on an own-bay is a
+        // local-only selection — no server command emitted. We verify the
+        // observable property flipped to prove the click handler ran.
+        var localButton = view.GetVisualDescendants()
+            .OfType<Button>()
+            .FirstOrDefault(b => b.Tag is StripBayViewModel bay && bay.Name == "LOCAL");
+        Assert.NotNull(localButton);
+
+        localButton!.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.NotNull(vm.SelectedBay);
+        Assert.Equal("LOCAL", vm.SelectedBay!.Name);
+        Assert.Empty(captured); // selecting an own bay does not send a canonical
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────
+
+    private static (VStripsViewModel Vm, List<(string Callsign, string Command)> Captured) MakeVm()
+    {
+        var captured = new List<(string, string)>();
+        var vm = new VStripsViewModel(
+            new ServerConnection(),
+            sendCommand: (cs, cmd, _) =>
+            {
+                captured.Add((cs, cmd));
+                return Task.CompletedTask;
+            },
+            preferences: null
+        );
+        return (vm, captured);
+    }
+
+    private static FlightStripsConfigDto SimpleConfig() =>
+        new(
+            FacilityId: "FAC1",
+            FacilityName: "Fresno ATCT",
+            Bays: [new StripBayConfigDto("bay-gnd", "GROUND", 2), new StripBayConfigDto("bay-loc", "LOCAL", 2)],
+            HasTwoPrinters: false,
+            SeparatorsLocked: false
+        );
+
+    // ApplyBayConfig posts to the dispatcher. Under an Avalonia.Headless test
+    // that's fine — RunJobs flushes. The reflection path in the unit-test MakeVm
+    // exists for non-Avalonia tests and is not needed here.
+    private static void SeedBays(VStripsViewModel vm, FlightStripsConfigDto config)
+    {
+        vm.ApplyBayConfig(config);
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static (Window window, VStripsView view) BootView(VStripsViewModel vm)
+    {
+        var view = new VStripsView { DataContext = vm };
+        var window = new Window
+        {
+            Width = 1000,
+            Height = 400,
+            Content = view,
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+        // Realize the bay ItemsControl — without this the DataTemplate containers
+        // may not be instantiated yet, and GetVisualDescendants misses them.
+        foreach (var itemsControl in view.GetVisualDescendants().OfType<ItemsControl>())
+        {
+            itemsControl.ApplyTemplate();
+            if (itemsControl.Presenter is ItemsPresenter presenter)
+            {
+                presenter.ApplyTemplate();
+            }
+        }
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Dispatcher.UIThread.RunJobs();
+        return (window, view);
+    }
+}

--- a/tests/Yaat.Client.UI.Tests/Yaat.Client.UI.Tests.csproj
+++ b/tests/Yaat.Client.UI.Tests/Yaat.Client.UI.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Avalonia.Headless.XUnit" Version="11.3.13" />
+    <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.7.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Yaat.Client\Yaat.Client.csproj" />
+    <ProjectReference Include="..\..\src\Yaat.Client.Core\Yaat.Client.Core.csproj" />
+    <ProjectReference Include="..\..\src\Yaat.Sim\Yaat.Sim.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Yaat.Client.UI.Tests/xunit.runner.json
+++ b/tests/Yaat.Client.UI.Tests/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": false
+}

--- a/yaat.slnx
+++ b/yaat.slnx
@@ -6,6 +6,7 @@
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/Yaat.Client.Tests/Yaat.Client.Tests.csproj" />
+    <Project Path="tests/Yaat.Client.UI.Tests/Yaat.Client.UI.Tests.csproj" />
     <Project Path="tests/Yaat.Sim.Tests/Yaat.Sim.Tests.csproj" />
   </Folder>
   <Folder Name="/tools/">


### PR DESCRIPTION
## Summary

Adds end-to-end support for Avalonia headless testing in `Yaat.Client` and the first wave of tests covering input dispatch, multi-window lifecycle, and flight-strip interactions. Three commits:

- **9c93809** — new `tests/Yaat.Client.UI.Tests/` project wired to `Avalonia.Headless.XUnit`, hosting the real `Yaat.Client.App` under a software platform. Smoke test confirms the lifetime boots.
- **bc25581** — routes the seven direct `TopLevel.StorageProvider` call sites through a new `IFilePickerService` abstraction so file-picker flows are mockable. `FakeFilePickerService` added for tests.
- **e46e0b4** — three headless test files (`CommandInputViewTests`, `MainWindowLifecycleTests`, `VStripsViewInteractionTests`), plus a `YaatPaths` helper that redirects every `%LOCALAPPDATA%/yaat` path through `YAAT_APPDATA_DIR`. The test project's `ModuleInitializer` sets the env var to `%TEMP%/yaat-ui-tests/<guid>/` before any YAAT static field initialises, so tests never touch the developer's real preferences, logs, or vNAS cache. `SmokeTests.YaatPaths_RedirectedToTempDir` is a regression guard.

## Test plan

- [x] Full solution build with warnings-as-errors — clean
- [x] Full test suite — 3637 passing (493 client + 13 UI + 3131 sim), 0 failures
- [x] Verified `%LOCALAPPDATA%/yaat/preferences.json` mtime is unchanged after a full test run
