### PR TITLE
feat: replace linear mag declination with NOAA WMM

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -3,6 +3,24 @@ Copyright (c) 2026 Leftos Aslanoglou
 Source code licensed under the MIT License (see LICENSE).
 
 ================================================================================
+Third-party libraries bundled with this project
+================================================================================
+
+## Geo (LGPL-3.0-or-later)
+
+YAAT dynamically links the `Geo` library for NOAA World Magnetic Model (WMM)
+computations. The library is consumed as an unmodified NuGet package reference,
+and end users may replace `Geo.dll` in the installed directory with a compatible
+build to satisfy LGPL §4(d)(1).
+
+  Upstream: https://github.com/sibartlett/Geo
+  Package:  https://www.nuget.org/packages/Geo/
+  License:  GNU Lesser General Public License v3.0 or later (LGPL-3.0-or-later)
+  Full text: https://www.gnu.org/licenses/lgpl-3.0.txt
+
+Copyright (c) Simon Bartlett and contributors.
+
+================================================================================
 Third-party data files bundled with this project
 ================================================================================
 

--- a/src/Yaat.Sim/MagneticDeclination.cs
+++ b/src/Yaat.Sim/MagneticDeclination.cs
@@ -1,31 +1,48 @@
+using Geo;
+using Geo.Geomagnetism;
+
 namespace Yaat.Sim;
 
 /// <summary>
-/// Approximate magnetic declination for CONUS. Uses a simple linear model based on
-/// longitude that's accurate to ~2-3 degrees — sufficient for ATC training purposes.
-/// FD winds are reported in true degrees; YAAT WindLayers use magnetic.
+/// Magnetic declination from the NOAA World Magnetic Model (WMM), via the <c>Geo</c> library.
+/// Globally accurate; no CONUS-only approximation. Declination is positive east of true north,
+/// negative west — matching the geodetic convention used throughout Yaat.Sim.
 /// </summary>
 public static class MagneticDeclination
 {
-    // Linear model: declination ≈ slope * longitude + intercept
-    // Derived from NOAA WMM 2025 data points across CONUS:
-    //   lon -125 → decl ~+14° (east), lon -70 → decl ~-14° (west)
-    // Slope ≈ (14 - (-14)) / (-125 - (-70)) = 28 / -55 ≈ -0.509
-    // Intercept ≈ -49.6°
-    private const double Slope = -0.509;
-    private const double Intercept = -49.6;
+    // WmmGeomagnetismCalculator performs stateless spherical-harmonic evaluation over its
+    // embedded coefficient tables; safe to share across threads.
+    private static readonly WmmGeomagnetismCalculator Calculator = new();
+
+    // WMM epochs last 5 years, so the model covering "now" is stable for the lifetime of the
+    // process. Resolve once at startup, then reuse — avoids a per-call LINQ scan of the 9
+    // embedded models on every tick, per aircraft.
+    private static readonly DateTime EpochDate = ResolveEpochDate();
+
+    private static DateTime ResolveEpochDate()
+    {
+        DateTime now = DateTime.UtcNow;
+        if (Calculator.Models.Any(m => m.ValidFrom <= now && m.ValidTo >= now))
+        {
+            return now;
+        }
+        // No embedded epoch covers the current date — clamp to the most recent epoch's last
+        // valid day so TryCalculate still returns a best-effort result. Triggers only if YAAT
+        // runs past the newest bundled WMM epoch (i.e. a stale package).
+        IGeomagneticModel newest = Calculator.Models.OrderBy(m => m.ValidTo).Last();
+        return newest.ValidTo.AddDays(-1.0);
+    }
 
     /// <summary>
-    /// Returns approximate magnetic declination in degrees.
+    /// Returns magnetic declination in degrees at the given location.
     /// Positive = east declination (magnetic north is east of true north).
     /// Negative = west declination (magnetic north is west of true north).
     /// To convert true→magnetic: magnetic = true - declination.
     /// </summary>
     public static double GetDeclination(double lat, double lon)
     {
-        // Simple linear model — lat has minor effect across CONUS, ignored
-        _ = lat;
-        return Slope * lon + Intercept;
+        GeomagnetismResult? result = Calculator.TryCalculate(new Coordinate(lat, lon), EpochDate);
+        return result?.Declination ?? 0.0;
     }
 
     /// <summary>

--- a/src/Yaat.Sim/Yaat.Sim.csproj
+++ b/src/Yaat.Sim/Yaat.Sim.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Geo" Version="1.2.0" />
     <PackageReference Include="Google.Protobuf" Version="3.29.5" />
     <PackageReference Include="Grpc.Tools" Version="2.71.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />

--- a/tests/Yaat.Sim.Tests/MagneticDeclinationTests.cs
+++ b/tests/Yaat.Sim.Tests/MagneticDeclinationTests.cs
@@ -7,31 +7,58 @@ public class MagneticDeclinationTests
     [Fact]
     public void GetDeclination_WestCoast_PositiveEast()
     {
-        // San Francisco area: lon ~-122 → expected ~+12-14° east declination
+        // San Francisco area: WMM 2025 ≈ +13° east declination.
         double decl = MagneticDeclination.GetDeclination(37.6, -122.4);
-        Assert.InRange(decl, 10.0, 16.0);
+        Assert.InRange(decl, 11.0, 15.0);
     }
 
     [Fact]
     public void GetDeclination_EastCoast_NegativeWest()
     {
-        // New York area: lon ~-74 → expected ~-12-14° west declination
+        // New York area: WMM 2025 ≈ -13° west declination.
         double decl = MagneticDeclination.GetDeclination(40.7, -74.0);
-        Assert.InRange(decl, -14.0, -10.0);
+        Assert.InRange(decl, -15.0, -11.0);
     }
 
     [Fact]
-    public void GetDeclination_CentralUS_NearZero()
+    public void GetDeclination_AgonicBand_SmallMagnitude()
     {
-        // Somewhere around lon -97 → declination near 0
-        double decl = MagneticDeclination.GetDeclination(39.0, -97.0);
-        Assert.InRange(decl, -2.0, 2.0);
+        // Near the WMM 2025 agonic line (through central US, ~lon -94W at 39N): expect |decl| < 4°.
+        double decl = MagneticDeclination.GetDeclination(39.0, -94.0);
+        Assert.InRange(decl, -4.0, 4.0);
+    }
+
+    [Fact]
+    public void GetDeclination_Honolulu_NotLinearModel()
+    {
+        // PHNL (21.3, -157.9): WMM ≈ +10° east. The old linear model gave ~+30.7° — catastrophically
+        // wrong for Pacific locations. Bound tight enough that a regression to the linear fit fails.
+        double decl = MagneticDeclination.GetDeclination(21.3, -157.9);
+        Assert.InRange(decl, 8.0, 12.0);
+    }
+
+    [Fact]
+    public void GetDeclination_Anchorage_NotLinearModel()
+    {
+        // PANC (61.2, -149.9): WMM ≈ +15° east. The old linear model gave ~+26.6° — far too large.
+        double decl = MagneticDeclination.GetDeclination(61.2, -149.9);
+        Assert.InRange(decl, 13.0, 18.0);
+    }
+
+    [Fact]
+    public void GetDeclination_LatitudeTerm_ChangesResult()
+    {
+        // The old linear model ignored latitude entirely. A real WMM query at the same longitude
+        // but different latitudes must produce meaningfully different values.
+        double south = MagneticDeclination.GetDeclination(25.0, -100.0);
+        double north = MagneticDeclination.GetDeclination(55.0, -100.0);
+        Assert.True(Math.Abs(south - north) > 0.5, $"Expected latitude-dependent variation; got south={south:F2} north={north:F2}");
     }
 
     [Fact]
     public void TrueToMagnetic_WestCoast()
     {
-        // True 270° on West Coast with ~+13° east declination → magnetic ~257°
+        // True 270° on West Coast with ~+13° east declination → magnetic ~257°.
         double mag = MagneticDeclination.TrueToMagnetic(270.0, 37.6, -122.4);
         Assert.InRange(mag, 254.0, 260.0);
     }
@@ -39,7 +66,7 @@ public class MagneticDeclinationTests
     [Fact]
     public void TrueToMagnetic_WrapsCorrectly()
     {
-        // True 5° with positive declination → should wrap past 360
+        // True 5° with positive east declination → should wrap past 360.
         double mag = MagneticDeclination.TrueToMagnetic(5.0, 37.6, -122.4);
         Assert.InRange(mag, 348.0, 358.0);
     }
@@ -47,8 +74,22 @@ public class MagneticDeclinationTests
     [Fact]
     public void TrueToMagnetic_EastCoast()
     {
-        // True 270° on East Coast with ~-12° west declination → magnetic ~282°
+        // True 270° on East Coast with ~-13° west declination → magnetic ~283°.
         double mag = MagneticDeclination.TrueToMagnetic(270.0, 40.7, -74.0);
         Assert.InRange(mag, 280.0, 286.0);
+    }
+
+    [Fact]
+    public void MagneticToTrue_RoundTrips()
+    {
+        // Any magnetic heading converted to true and back must return the original to float precision.
+        const double lat = 37.6;
+        const double lon = -122.4;
+        foreach (double heading in new[] { 0.0, 90.0, 180.0, 270.0, 359.9 })
+        {
+            double trueHdg = MagneticDeclination.MagneticToTrue(heading, lat, lon);
+            double roundTrip = MagneticDeclination.TrueToMagnetic(trueHdg, lat, lon);
+            Assert.Equal(heading, roundTrip, precision: 6);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Replaces the CONUS-only linear declination fit in `MagneticDeclination` with the NOAA World Magnetic Model via the `Geo` library (LGPL-3.0-or-later, dynamically linked). Public API and positive=east convention unchanged — all existing call sites work untouched.
- WMM epoch is resolved once at startup and cached; avoids a per-tick LINQ scan over 9 embedded models for every aircraft.
- `NOTICE` adds LGPL-3.0 attribution for Geo with the §4(d)(1) replaceable-assembly note so the installer ships correct third-party notices.
- Tests tightened for CONUS, plus new non-CONUS cases (PHNL +10 deg vs old linear +30.7 deg, PANC +15 deg vs old linear +26.6 deg), a latitude-dependence test, and a round-trip test.

## Test plan
- [x] Full solution build with warnings-as-errors — 0 warnings, 0 errors
- [x] Full test suite — 3,692 tests pass (506 Client + 18 UI + 3168 Sim)
- [x] `MagneticDeclinationTests` — all 10 pass (6 existing with tightened bounds, 4 new)
- [ ] Spot-check radar north-up rotation and scenario wind direction at KSFO in the running client