### PR TITLE
fix: stop nested consolidation override double-counting a descendant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Fixed
+- Manually consolidating a position into one TCP while a position below it in the hierarchy is consolidated into a different TCP no longer shows the lower position consolidated under both owners at once on the STARS scope. The nested position now follows only its own consolidation.
 - An aircraft sent around (`GA`) and then given a heading (`FH`) during the missed-approach climb now holds the published missed-approach altitude, instead of reverting to the altitude it was last cleared to for the approach — which could leave it leveling off too low or climbing past the missed-approach altitude.
 - Saying "expedite" after an altitude over voice (e.g. "climb and maintain five thousand, expedite") no longer drops the word and mangles the altitude into a bogus runway. Speech recognition was mistaking long words that end in a runway-suffix sound ("expedite", "tonight") for a "left"/"right"/"center" runway designator.
 

--- a/src/Yaat.Sim/Simulation/ConsolidationEngine.cs
+++ b/src/Yaat.Sim/Simulation/ConsolidationEngine.cs
@@ -124,8 +124,11 @@ public static class ConsolidationEngine
                 }
 
                 // Also add descendants of the sending TCP that aren't
-                // independently attended
-                var descendants = CollectConsolidatedDescendants(sendingTcp, childrenOf, isAttended);
+                // independently attended. Exclude TCPs that carry their own
+                // manual override (manuallyOverriddenIds) — they follow their
+                // own override receiver, not this sender's, and would otherwise
+                // be double-counted under both owners.
+                var descendants = CollectConsolidatedDescendants(sendingTcp, childrenOf, isAttended, manuallyOverriddenIds);
                 foreach (var desc in descendants)
                 {
                     if (desc.Id != sendingTcp.Id && !ownerResult.Children.Contains(desc))

--- a/tests/Yaat.Sim.Tests/ManualConsolidationTests.cs
+++ b/tests/Yaat.Sim.Tests/ManualConsolidationTests.cs
@@ -345,6 +345,37 @@ public class ManualConsolidationTests
     }
 
     [Fact]
+    public void ManualOverride_NestedOverriddenDescendant_NotDoubleCounted()
+    {
+        var state = new ConsolidationState();
+
+        // 1T and 1G attended.
+        var attended = new HashSet<string> { IdT, IdG };
+        Func<Tcp, bool> isAttended = tcp => attended.Contains(tcp.Id);
+
+        // 1F (child of 1T) is consolidated into 1G.
+        state.Consolidate(Tcp1G, Tcp1F, basic: false); // 1F → 1G
+        // 1S, a *descendant* of 1F, is SEPARATELY consolidated into 1T.
+        state.Consolidate(Tcp1T, Tcp1S, basic: false); // 1S → 1T
+
+        var items = ConsolidationEngine.GetConsolidationItems(AllTcps, true, isAttended, state);
+
+        // 1S's own item owner is 1T — its explicit override wins.
+        Assert.Equal(IdT, FindItem(items, IdS).Owner!.Id);
+
+        var gChildren = ChildIds(FindItem(items, IdG));
+        var tChildren = ChildIds(FindItem(items, IdT));
+
+        // 1S is consolidated under 1T, so it must appear under 1T...
+        Assert.Contains(IdS, tChildren);
+        // ...and must NOT ALSO be double-listed under 1G (1F's override receiver).
+        Assert.DoesNotContain(IdS, gChildren);
+
+        // 1F itself still follows its own override into 1G.
+        Assert.Contains(IdF, gChildren);
+    }
+
+    [Fact]
     public void ManualConsolidation_DescendantsOfSendingTcpFollowOverride()
     {
         var state = new ConsolidationState();


### PR DESCRIPTION
Fixes #201.

## Problem

`ConsolidationEngine.GetConsolidationItems` could list a single TCP as a consolidated child of **two owners at once** when manual consolidation overrides are nested — a position consolidated into one TCP while one of its hierarchy descendants is separately consolidated into a different TCP. Because `StarsConsolidation` is a full-replacement topic, the scope shows the descendant under both owners, contradicting its own `Owner` field.

## Fix

The manual-override children build runs in two passes. The first pass already excludes separately-overridden TCPs (`excludeIds: manuallyOverriddenIds`) from an attended TCP's descendant walk; the second pass (appending an overridden sender's descendants to its receiver) omitted that exclude set. This one-line change passes `manuallyOverriddenIds` to the second-pass `CollectConsolidatedDescendants` call so a descendant with its own override follows only its own receiver. The sender is always added as the walk root, so non-overridden descendants still follow the sender.

This matches the contract stated in `docs/track-sharing-and-consolidation.md` ("so a sender isn't double-counted under both its natural ancestor and its override receiver").

## Self-verifying

Commits both the fix and a repro test (`ManualConsolidationTests.ManualOverride_NestedOverriddenDescendant_NotDoubleCounted`) that fails on the pre-fix engine and passes with the change.

- 42 Yaat.Sim consolidation/pointout tests pass.
- 32 yaat-server `*Consolidation*` tests pass (no cross-repo regression).
- `dotnet build src/Yaat.Sim -p:TreatWarningsAsErrors=true` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)