### PR TITLE
fix: decode FL300+ winds aloft with unsigned FD temperatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Live winds aloft above FL240 (the 30,000 / 34,000 / 39,000 ft levels) are now decoded instead of silently dropped. The FAA winds-aloft (FD) bulletin omits the temperature sign at those levels — always-negative aloft — so groups like `257840` arrived as 6 characters and were rejected by the decoder; aircraft cruising in the flight levels under live weather were getting wind clamped to the 24,000 ft layer. Scenario weather was unaffected.
+
 ## v0.7.26-beta [2026/06/23]
 
 ### Highlights

--- a/src/Yaat.Sim/WindsAloftParser.cs
+++ b/src/Yaat.Sim/WindsAloftParser.cs
@@ -163,11 +163,18 @@ public static class WindsAloftParser
     /// </summary>
     internal static WindAtLevel? DecodeWind(int altitudeFt, string code)
     {
-        // Strip temperature suffix (e.g., "2714-08" → "2714", "2321+03" → "2321")
+        // Strip temperature suffix (e.g., "2714-08" → "2714", "2321+03" → "2321").
         int signIdx = code.IndexOfAny(['+', '-']);
         if (signIdx >= 4)
         {
             code = code[..signIdx];
+        }
+        else if (code.Length > 4)
+        {
+            // At FL300 and above the bulletin omits the (always-negative) temperature sign,
+            // producing a 6-char "DDSSTT" group (e.g. "257840" = 250°/78kt/-40°C). Strip the
+            // trailing temperature so the wind still decodes instead of being rejected.
+            code = code[..4];
         }
 
         // Must be exactly 4 digits

--- a/tests/Yaat.Sim.Tests/WindsAloftParserTests.cs
+++ b/tests/Yaat.Sim.Tests/WindsAloftParserTests.cs
@@ -124,4 +124,34 @@ public class WindsAloftParserTests
         Assert.Equal(360, wind.Value.DirectionTrue);
         Assert.Equal(10, wind.Value.SpeedKts);
     }
+
+    [Fact]
+    public void DecodeWind_HighAltitudeUnsignedTemperature()
+    {
+        // At FL300 and above the FD bulletin omits the (always-negative) temperature sign,
+        // producing a 6-char "DDSSTT" group. "521463" → DD=52 ≥ 50 → direction (52-50)*10 = 020°,
+        // speed 14+100 = 114 kt; the trailing "63" (= -63 °C) must be stripped, not rejected.
+        var wind = WindsAloftParser.DecodeWind(39000, "521463");
+        Assert.NotNull(wind);
+        Assert.Equal(20, wind.Value.DirectionTrue);
+        Assert.Equal(114, wind.Value.SpeedKts);
+        Assert.False(wind.Value.IsLightVariable);
+    }
+
+    [Fact]
+    public void Parse_HighAltitudeLevels_DecodeFromUnsignedGroups()
+    {
+        // The 30000/34000/39000 columns in SampleFd use 6-char unsigned-temperature groups
+        // (header note "TEMPS NEG ABV 24000"). They must still decode into wind layers.
+        var sfo = WindsAloftParser.Parse(SampleFd)[0];
+
+        Assert.Contains(sfo.Winds, w => w.AltitudeFt == 30000);
+        Assert.Contains(sfo.Winds, w => w.AltitudeFt == 34000);
+        Assert.Contains(sfo.Winds, w => w.AltitudeFt == 39000);
+
+        // SFO 30000 = "257840" → 250° at 78 kt.
+        var w30000 = sfo.Winds.First(w => w.AltitudeFt == 30000);
+        Assert.Equal(250, w30000.DirectionTrue);
+        Assert.Equal(78, w30000.SpeedKts);
+    }
 }


### PR DESCRIPTION
Fixes #218.

## What

`WindsAloftParser.DecodeWind` rejected FD (winds-aloft) data groups at FL300 / FL340 / FL390, so live winds aloft above FL240 were silently dropped and flight-level aircraft under live weather got their wind clamped to the 24,000 ft layer (wrong crab/WCA + groundspeed at altitude). Scenario/file weather was unaffected.

The FD bulletin omits the temperature sign at those levels (always negative aloft — `TEMPS NEG ABV 24000`), so a group is 6 chars `DDSSTT`, e.g. `257840` = 250°/78 kt/−40 °C. The decoder only stripped a temperature when an explicit `+`/`-` sign was present, so the unsigned high-level groups failed the `length != 4` check and returned `null`.

## Fix

Strip the trailing unsigned 2-digit temperature when no sign is present and the group is longer than 4 chars (`src/Yaat.Sim/WindsAloftParser.cs`). The signed (≤FL240) and bare (3,000 ft) paths are untouched; `9900xx` still routes through the existing light-and-variable branch.

## Tests

Self-verifying — the commit includes both the fix and the failing-then-passing regression tests:
- `DecodeWind_HighAltitudeUnsignedTemperature` — unit decode of an unsigned `DDSSTT` group.
- `Parse_HighAltitudeLevels_DecodeFromUnsignedGroups` — end-to-end Parse over the 30/34/39k columns of the existing `SampleFd`.

Both fail on `main` (parsed winds stop at 24,000 ft) and pass with the fix. `dotnet build src/Yaat.Sim -p:TreatWarningsAsErrors=true` is clean; `WindsAloftParserTests` (13) and the client `LiveWeatherRealDataTests` (7) all pass.

## Confidence

High — mechanical, scope-limited to FD temperature stripping, grounded in real FD bulletin format and the cached `zoa_fd_winds.txt` fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
