### PR TITLE
fix: zero-pad RunwayIdentifier inferred opposite end (19-27 → 01-09)

### DIFF
--- a/src/Yaat.Sim/Data/Airport/RunwayIdentifier.cs
+++ b/src/Yaat.Sim/Data/Airport/RunwayIdentifier.cs
@@ -98,7 +98,9 @@ public readonly struct RunwayIdentifier : IEquatable<RunwayIdentifier>
             _ => suffix,
         };
 
-        return $"{opposite}{oppSuffix}";
+        // Normalize so the inferred opposite is zero-padded like every other stored end
+        // (e.g. opposite of "19" is "01", not "1"); an unpadded end is unmatchable by Contains.
+        return Normalize($"{opposite}{oppSuffix}");
     }
 
     /// <summary>

--- a/tests/Yaat.Sim.Tests/RunwayIdentifierTests.cs
+++ b/tests/Yaat.Sim.Tests/RunwayIdentifierTests.cs
@@ -28,12 +28,36 @@ public class RunwayIdentifierTests
     [InlineData("1", "01", "19")]
     [InlineData("10C", "10C", "28C")]
     [InlineData("12R", "12R", "30L")]
+    // Inferred opposites in the 01-09 range must be zero-padded like every other stored end
+    // (KDCA 01/19, KSAN 09/27, etc.). Constructed from the high end, the opposite is single-digit
+    // and must still be normalized to two digits.
+    [InlineData("19", "19", "01")]
+    [InlineData("27", "27", "09")]
+    [InlineData("19L", "19L", "01R")]
+    [InlineData("26L", "26L", "08R")]
     public void SingleEndConstructor_InfersOpposite(string designator, string expectedEnd1, string expectedOpposite)
     {
         var id = new RunwayIdentifier(designator);
 
         Assert.Equal(expectedEnd1, id.End1);
         Assert.Equal(expectedOpposite, id.End2);
+    }
+
+    [Theory]
+    [InlineData("19")]
+    [InlineData("27L")]
+    [InlineData("21C")]
+    public void SingleEndConstructor_OppositeEndIsMatchableByContains(string highEnd)
+    {
+        // The inferred opposite end must be matchable by Contains in both padded and FAA
+        // (leading-zero-stripped) spellings — the same contract Contains_SingleDigit_MatchesTwoDigit
+        // asserts for the primary end. Ground pathfinding and CROSS/hold-short matching rely on it.
+        var id = new RunwayIdentifier(highEnd);
+        var oppositePadded = id.End2; // e.g. "01", "09L", "03C"
+        var oppositeFaa = RunwayIdentifier.ToDisplayDesignator(oppositePadded); // e.g. "1", "9L", "3C"
+
+        Assert.True(id.Contains(oppositePadded), $"Contains('{oppositePadded}') should match stored End2");
+        Assert.True(id.Contains(oppositeFaa), $"Contains('{oppositeFaa}') should match stored End2");
     }
 
     [Theory]


### PR DESCRIPTION
Fixes #271.

## What

`RunwayIdentifier.ComputeOpposite` returned the inferred opposite runway designator **unpadded**. A `RunwayIdentifier` built from a single high end in 19–27 therefore stored its opposite end as e.g. `"1"` / `"1R"` instead of `"01"` / `"01R"`, breaking the class's two-digit normalization invariant. Because `Contains()`/`Equals()` normalize the *query* to two digits before comparing, the unpadded opposite end became **unmatchable in any spelling**.

## Fix (one line)

`ComputeOpposite` now normalizes its result:

```csharp
return Normalize($"{opposite}{oppSuffix}");
```

## Verification

- Repro test added over the previously-untested high→low direction (`SingleEndConstructor_InfersOpposite` cases `19/27/19L/26L`, plus `SingleEndConstructor_OppositeEndIsMatchableByContains`). Confirmed **FAILS** on the parent commit (`Expected "01R" / Actual "1R"`; `Contains('1')` false) and **passes** with the fix.
- `dotnet build src/Yaat.Sim -p:TreatWarningsAsErrors=true` → 0 warnings.
- `RunwayIdentifierTests` (64) + ground/pathfinding suites (`Pathfinding`, `HoldShortAnnotator`, `GroundCommandHandler`, `AirportE2E`) — 328 tests pass.
- No existing test relied on the unpadded form (all `ComputeOpposite_Correct` cases are already two-digit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
