### PR TITLE
fix: zero-pad single-digit runway before STAR transition lookup (#273)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- An arrival cleared onto a STAR with a single-digit runway (runways 1–9, e.g. `JARR BDEGA 1R`) now flies the published runway-transition legs and shows them on the **Show nav route** overlay and STARS programmed-fix highlighting, instead of silently dropping the transition. Scenario aircraft spawned on such a STAR are fixed the same way. Previously only the zero-padded form (`01R`) resolved the transition.
+
 ## v0.9.2-beta [2026/07/06]
 
 ### Highlights

--- a/src/Yaat.Client/Services/ShownRouteBuilder.cs
+++ b/src/Yaat.Client/Services/ShownRouteBuilder.cs
@@ -2,6 +2,7 @@ using Yaat.Client.Models;
 using Yaat.Client.ViewModels;
 using Yaat.Sim;
 using Yaat.Sim.Data;
+using Yaat.Sim.Data.Airport;
 using Yaat.Sim.Data.Vnas;
 using Yaat.Sim.Phases;
 
@@ -232,25 +233,20 @@ internal static class ShownRouteBuilder
 
     private static string? MatchRunwayTransitionKey(IReadOnlyDictionary<string, CifpTransition> transitions, string runway)
     {
-        // CIFP runway-transition keys are typically "RW28R", "RW10L", etc. The caller passes
-        // the bare designator ("28R") — accept both forms.
-        if (transitions.ContainsKey(runway))
+        // CIFP runway-transition keys are zero-padded ("RW01R", "RW28R"). The caller passes the bare
+        // designator ("28R", "1R") or an already-prefixed key. Strip an optional leading "RW", zero-pad
+        // the designator, then rebuild the exact key — a naive suffix match would bind "1R" to "RW11R"
+        // or "RW31R". Mirrors NavigationCommandHandler.LookupRunwayTransition (issue #273).
+        var designator = RunwayIdentifier.NormalizeDesignator(runway.StartsWith("RW", StringComparison.OrdinalIgnoreCase) ? runway[2..] : runway);
+        var rwKey = "RW" + designator;
+        if (transitions.ContainsKey(rwKey))
         {
-            return runway;
+            return rwKey;
         }
-        var prefixed = $"RW{runway}";
-        if (transitions.ContainsKey(prefixed))
-        {
-            return prefixed;
-        }
-        foreach (var key in transitions.Keys)
-        {
-            if (key.EndsWith(runway, StringComparison.OrdinalIgnoreCase))
-            {
-                return key;
-            }
-        }
-        return null;
+
+        // CIFP "B" key means both parallels share one transition (e.g. "RW01B" serves RW01L/RW01R).
+        var bothKey = "RW" + designator.TrimEnd('L', 'R', 'C') + "B";
+        return transitions.ContainsKey(bothKey) ? bothKey : null;
     }
 
     private static VectorTail? TryExtractTrailingVector(IReadOnlyList<CifpLeg> legs, NavigationDatabase navDb)

--- a/src/Yaat.Sim/Commands/NavigationCommandHandler.cs
+++ b/src/Yaat.Sim/Commands/NavigationCommandHandler.cs
@@ -504,12 +504,15 @@ internal static class NavigationCommandHandler
     /// </summary>
     internal static CifpTransition? LookupRunwayTransition(IReadOnlyDictionary<string, CifpTransition> transitions, string runwayDesignator)
     {
-        var rwKey = "RW" + runwayDesignator;
+        // CIFP runway-transition keys are zero-padded ("RW01R"); a controller-typed single-digit
+        // designator ("1R") must be padded before the lookup or it silently misses the transition.
+        var designator = RunwayIdentifier.NormalizeDesignator(runwayDesignator);
+        var rwKey = "RW" + designator;
         if (transitions.TryGetValue(rwKey, out var rwTransition))
         {
             return rwTransition;
         }
-        var bothKey = "RW" + runwayDesignator.TrimEnd('L', 'R', 'C') + "B";
+        var bothKey = "RW" + designator.TrimEnd('L', 'R', 'C') + "B";
         return transitions.TryGetValue(bothKey, out var bothTransition) ? bothTransition : null;
     }
 

--- a/src/Yaat.Sim/Commands/NavigationCommandHandler.cs
+++ b/src/Yaat.Sim/Commands/NavigationCommandHandler.cs
@@ -307,10 +307,12 @@ internal static class NavigationCommandHandler
         }
 
         // A runway-transition argument (JARR star 27) also designates the landing runway, so the
-        // CIFP runway-transition lookup and downstream approach selection use it.
+        // CIFP runway-transition lookup and downstream approach selection use it. Zero-pad it to the
+        // same form as RunwayInfo.Designator so a single-digit designator ("1R") matches the CIFP
+        // "RW01R" key rather than silently dropping the transition (issue #273).
         if (cmd.RunwayTransition is { } runwayArg)
         {
-            aircraft.Procedure.DestinationRunway = runwayArg;
+            aircraft.Procedure.DestinationRunway = RunwayIdentifier.NormalizeDesignator(runwayArg);
         }
 
         // Try CIFP STAR first for constrained navigation targets

--- a/src/Yaat.Sim/Data/NavigationDatabase.cs
+++ b/src/Yaat.Sim/Data/NavigationDatabase.cs
@@ -1425,8 +1425,10 @@ public sealed class NavigationDatabase
             return null;
         }
 
-        // Normalize runway ID: "30" → "RW30", "30L" → "RW30L"
-        string rwyKey = runwayId.StartsWith("RW", StringComparison.OrdinalIgnoreCase) ? runwayId : $"RW{runwayId}";
+        // Normalize runway ID: "30" → "RW30", "8L" → "RW08L", "RW30" → "RW30". CIFP runway-transition
+        // keys are zero-padded, so a single-digit designator must be padded or the lookup misses.
+        string designator = runwayId.StartsWith("RW", StringComparison.OrdinalIgnoreCase) ? runwayId[2..] : runwayId;
+        string rwyKey = "RW" + RunwayIdentifier.NormalizeDesignator(designator);
 
         foreach (var (key, transition) in star.RunwayTransitions)
         {

--- a/src/Yaat.Sim/Scenarios/AircraftGenerator.cs
+++ b/src/Yaat.Sim/Scenarios/AircraftGenerator.cs
@@ -483,7 +483,9 @@ public static class AircraftGenerator
         };
 
         // The runway-transition designator drives both the lateral route build and the descend-via profile.
-        state.Procedure.DestinationRunway = request.StarRunway;
+        // Zero-pad it (SpawnParser leaves single-digit designators unpadded) so it matches the CIFP
+        // "RW01R" key and the RunwayInfo.Designator invariant (issue #273).
+        state.Procedure.DestinationRunway = request.StarRunway is { } starRunway ? RunwayIdentifier.NormalizeDesignator(starRunway) : null;
 
         var warnings = new List<string>();
         ArrivalRouteResolver.PopulateNavigationRoute(state, navPath, warnings);

--- a/src/Yaat.Sim/Scenarios/ArrivalRouteResolver.cs
+++ b/src/Yaat.Sim/Scenarios/ArrivalRouteResolver.cs
@@ -1,5 +1,6 @@
 using Yaat.Sim.Commands;
 using Yaat.Sim.Data;
+using Yaat.Sim.Data.Airport;
 using Yaat.Sim.Data.Vnas;
 
 namespace Yaat.Sim.Scenarios;
@@ -262,14 +263,16 @@ internal static class ArrivalRouteResolver
             return null;
         }
 
-        var rwKey = "RW" + designator;
+        // CIFP runway-transition keys are zero-padded ("RW01R"); pad a single-digit designator first.
+        var padded = RunwayIdentifier.NormalizeDesignator(designator);
+        var rwKey = "RW" + padded;
         if (star.RunwayTransitions.TryGetValue(rwKey, out var transition))
         {
             return transition.Legs;
         }
 
         // Fall back to "both" key (e.g., RW19B for RW19L/RW19R)
-        var bothKey = "RW" + designator.TrimEnd('L', 'R', 'C') + "B";
+        var bothKey = "RW" + padded.TrimEnd('L', 'R', 'C') + "B";
         if (star.RunwayTransitions.TryGetValue(bothKey, out transition))
         {
             return transition.Legs;

--- a/tests/Yaat.Client.Tests/Services/ShownRouteBuilderTests.cs
+++ b/tests/Yaat.Client.Tests/Services/ShownRouteBuilderTests.cs
@@ -120,6 +120,101 @@ public class ShownRouteBuilderTests
     }
 
     [Fact]
+    public void BuildPrimary_SingleDigitRunway_ResolvesPaddedRunwayTransitionVector()
+    {
+        // Aircraft assigned runway 1R; the STAR publishes the transition under the zero-padded CIFP
+        // key "RW01R". The client must pad "1R" → "RW01R" and produce that transition's vector tail
+        // (issue #273).
+        var rwyTransition = new CifpTransition(
+            "RW01R",
+            [
+                new CifpLeg("CRSEN", CifpPathTerminator.TF, null, null, null, CifpFixRole.None, 10, null, null, null),
+                new CifpLeg("CRSEN", CifpPathTerminator.FM, null, null, null, CifpFixRole.None, 20, OutboundCourse: 112.0, null, null),
+            ]
+        );
+
+        var stars = new[]
+        {
+            new CifpStarProcedure(
+                Airport,
+                "WNDSR2",
+                CommonLegs: [new CifpLeg("HOPTA", CifpPathTerminator.IF, null, null, null, CifpFixRole.IF, 10, null, null, null)],
+                EnrouteTransitions: new Dictionary<string, CifpTransition>(),
+                RunwayTransitions: new Dictionary<string, CifpTransition>(StringComparer.OrdinalIgnoreCase) { ["RW01R"] = rwyTransition }
+            ),
+        };
+
+        var fixes = new Dictionary<string, (double Lat, double Lon)>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["HOPTA"] = (37.78, -122.15),
+            ["CRSEN"] = (37.69, -122.01),
+        };
+
+        var navDb = NavigationDatabase.ForTesting(fixes, null, null, null, null, stars);
+
+        var ac = new AircraftModel
+        {
+            Callsign = "SWA1234",
+            Destination = Airport,
+            ActiveStarId = "WNDSR2",
+            DestinationRunway = "1R",
+            NavRouteFixes = [new NavRouteFixDto("HOPTA", 37.78, -122.15, null)],
+        };
+
+        var (_, tail) = ShownRouteBuilder.BuildPrimary(ac, navDb);
+
+        Assert.NotNull(tail);
+        Assert.Equal(112.0, tail!.HeadingMag, 3);
+    }
+
+    [Fact]
+    public void BuildPrimary_SingleDigitRunway_DoesNotSuffixMatchDifferentRunwayTransition()
+    {
+        // Aircraft assigned runway 1R, but the STAR only publishes an RW31R transition. The old
+        // EndsWith fallback ("RW31R".EndsWith("1R")) wrongly bound the 31R vector; zero-padding
+        // "1R" → "RW01R" finds no transition, so no vector tail is produced (issue #273).
+        var rwyTransition = new CifpTransition(
+            "RW31R",
+            [
+                new CifpLeg("CRSEN", CifpPathTerminator.TF, null, null, null, CifpFixRole.None, 10, null, null, null),
+                new CifpLeg("CRSEN", CifpPathTerminator.FM, null, null, null, CifpFixRole.None, 20, OutboundCourse: 112.0, null, null),
+            ]
+        );
+
+        var stars = new[]
+        {
+            new CifpStarProcedure(
+                Airport,
+                "WNDSR2",
+                CommonLegs: [new CifpLeg("HOPTA", CifpPathTerminator.IF, null, null, null, CifpFixRole.IF, 10, null, null, null)],
+                EnrouteTransitions: new Dictionary<string, CifpTransition>(),
+                RunwayTransitions: new Dictionary<string, CifpTransition>(StringComparer.OrdinalIgnoreCase) { ["RW31R"] = rwyTransition }
+            ),
+        };
+
+        var fixes = new Dictionary<string, (double Lat, double Lon)>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["HOPTA"] = (37.78, -122.15),
+            ["CRSEN"] = (37.69, -122.01),
+        };
+
+        var navDb = NavigationDatabase.ForTesting(fixes, null, null, null, null, stars);
+
+        var ac = new AircraftModel
+        {
+            Callsign = "SWA1234",
+            Destination = Airport,
+            ActiveStarId = "WNDSR2",
+            DestinationRunway = "1R",
+            NavRouteFixes = [new NavRouteFixDto("HOPTA", 37.78, -122.15, null)],
+        };
+
+        var (_, tail) = ShownRouteBuilder.BuildPrimary(ac, navDb);
+
+        Assert.Null(tail);
+    }
+
+    [Fact]
     public void BuildPrimary_StarEndingAtFix_NoVectorLeg_ReturnsNullTail()
     {
         var stars = new[]

--- a/tests/Yaat.Sim.Tests/ProcedureLoadingTests.cs
+++ b/tests/Yaat.Sim.Tests/ProcedureLoadingTests.cs
@@ -355,6 +355,25 @@ public class ProcedureLoadingTests
         Assert.Contains(aircraft.Targets.NavigationRoute, t => t.Name == "BRIXX");
     }
 
+    [Fact]
+    public void Jarr_SingleDigitRunwayTransition_StoresPaddedDestinationRunway()
+    {
+        var aircraft = CreateIfrAircraft("KSFO BDEGA3 BDEGA3.BDEGA");
+        aircraft.Altitude = 20000;
+
+        var navDb = CreateNavDb(star: CreateTestStar());
+        using var _ = NavigationDatabase.ScopedOverride(navDb);
+
+        // A single-digit runway-transition arg ("1R") must be stored zero-padded ("01R"), matching the
+        // RunwayInfo.Designator invariant, so every downstream "RW" + designator lookup finds the
+        // CIFP-stored "RW01R" key instead of silently missing (issue #273).
+        var cmd = new JoinStarCommand("BDEGA3", "BDEGA", "1R");
+        var result = CommandDispatcher.Dispatch(cmd, aircraft, TestDispatch.Context(Random.Shared));
+
+        Assert.True(result.Success);
+        Assert.Equal("01R", aircraft.Procedure.DestinationRunway);
+    }
+
     // --- DVIA self-resolve from filed route (issue #187) ---
 
     [Fact]

--- a/tests/Yaat.Sim.Tests/StarSingleDigitRunwayTransitionTests.cs
+++ b/tests/Yaat.Sim.Tests/StarSingleDigitRunwayTransitionTests.cs
@@ -1,0 +1,72 @@
+using Xunit;
+using Yaat.Sim.Commands;
+using Yaat.Sim.Data;
+
+namespace Yaat.Sim.Tests;
+
+/// <summary>
+/// A controller issuing a STAR with a single-digit runway transition (e.g. <c>JARR BDEGA 1R</c>)
+/// must resolve the same CIFP runway-transition legs as the zero-padded form (<c>01R</c>). The
+/// JARR parser passes the runway token through unnormalized (see <see cref="JarrOverloadTests"/>),
+/// and every runway-transition lookup builds its key as <c>"RW" + designator</c>. A single-digit
+/// designator therefore produces <c>"RW1R"</c>, which never matches the CIFP-stored <c>"RW01R"</c>,
+/// silently dropping the runway-transition legs from the flown route.
+///
+/// Real data: KSFO BDEGA STAR has an <c>RW01R</c> runway transition (BDEGA -&gt; CORKK -&gt; BRIXX).
+///
+/// See https://github.com/leftos/yaat/issues/273.
+/// </summary>
+[Collection("NavDbMutator")]
+public class StarSingleDigitRunwayTransitionTests : IDisposable
+{
+    private readonly IDisposable _scope;
+
+    public StarSingleDigitRunwayTransitionTests()
+    {
+        TestVnasData.EnsureInitialized();
+        _scope = NavigationDatabase.ScopedOverride(TestVnasData.NavigationDb!);
+    }
+
+    public void Dispose() => _scope.Dispose();
+
+    [Fact]
+    public void Parser_SingleDigitRunway_PassesDesignatorUnnormalized()
+    {
+        // Entry point: the JARR parser hands the handler a bare "1R" (accepted by IsRunwayDesignator).
+        var result = CommandParser.Parse("JARR BDEGA 1R");
+        Assert.True(result.IsSuccess, $"parse failed: {result.Reason}");
+        var cmd = Assert.IsType<JoinStarCommand>(result.Value);
+        Assert.Equal("1R", cmd.RunwayTransition);
+    }
+
+    [Fact]
+    public void LookupRunwayTransition_SingleDigitRunway_ResolvesSameAsPadded()
+    {
+        var star = NavigationDatabase.Instance.GetStar("KSFO", "BDEGA4");
+        Assert.NotNull(star);
+
+        // Real-data sanity: KSFO BDEGA carries a single-digit (01x) runway transition.
+        var padded = NavigationCommandHandler.LookupRunwayTransition(star!.RunwayTransitions, "01R");
+        Assert.NotNull(padded);
+
+        // Flown-route path: TryResolveStarFromCifp resolves the runway transition via this exact
+        // helper. A single-digit designator must resolve the same transition legs.
+        var singleDigit = NavigationCommandHandler.LookupRunwayTransition(star.RunwayTransitions, "1R");
+        Assert.NotNull(singleDigit);
+        Assert.Equal(padded!.Legs.Count, singleDigit!.Legs.Count);
+    }
+
+    [Fact]
+    public void GetStarRunwayTransitions_SingleDigitRunway_ResolvesSameAsPadded()
+    {
+        var navDb = NavigationDatabase.Instance;
+
+        var padded = navDb.GetStarRunwayTransitions("KSFO", "BDEGA4", "01R");
+        Assert.NotNull(padded);
+        Assert.NotEmpty(padded!);
+
+        var singleDigit = navDb.GetStarRunwayTransitions("KSFO", "BDEGA4", "1R");
+        Assert.NotNull(singleDigit);
+        Assert.Equal(padded, singleDigit);
+    }
+}

--- a/tests/Yaat.Sim.Tests/StarSingleDigitRunwayTransitionTests.cs
+++ b/tests/Yaat.Sim.Tests/StarSingleDigitRunwayTransitionTests.cs
@@ -1,6 +1,8 @@
 using Xunit;
 using Yaat.Sim.Commands;
 using Yaat.Sim.Data;
+using Yaat.Sim.Data.Vnas;
+using Yaat.Sim.Scenarios;
 
 namespace Yaat.Sim.Tests;
 
@@ -68,5 +70,45 @@ public class StarSingleDigitRunwayTransitionTests : IDisposable
         var singleDigit = navDb.GetStarRunwayTransitions("KSFO", "BDEGA4", "1R");
         Assert.NotNull(singleDigit);
         Assert.Equal(padded, singleDigit);
+    }
+
+    [Fact]
+    public void SpawnOnStar_SingleDigitRunway_StoresPaddedDestinationRunway()
+    {
+        // Scenario "OnStar" spawns write StarRunway (uppercased-but-unpadded by SpawnParser) straight
+        // into Procedure.DestinationRunway. A single-digit spawn ("1R") must be zero-padded ("01R") so
+        // the flown-route and restriction lookups match the CIFP "RW01R" key (issue #273).
+        var navDb = NavigationDatabase.Instance;
+        var star = navDb.GetStar("KSFO", "BDEGA4");
+        if (star is null || star.CommonLegs.Count == 0 || !star.RunwayTransitions.ContainsKey("RW01R"))
+        {
+            return; // offline CIFP fallback lacks BDEGA4/RW01R
+        }
+
+        var targets = DepartureClearanceHandler.ResolveLegsToTargets(new List<CifpLeg>(star.CommonLegs));
+        if (targets.Count == 0 || navDb.GetFixPosition(targets[0].Name) is null)
+        {
+            return;
+        }
+
+        var request = new SpawnRequest
+        {
+            Rules = FlightRulesKind.Ifr,
+            Weight = WeightClass.Heavy,
+            Engine = EngineKind.Jet,
+            PositionType = SpawnPositionType.OnStar,
+            StarEntryFix = targets[0].Name,
+            StarId = "BDEGA4",
+            StarRunway = "1R",
+            DescendVia = false,
+            StarAltitude = null,
+            DestinationAirportId = "KSFO",
+        };
+
+        var (state, error) = AircraftGenerator.Generate(request, "KSFO", Array.Empty<AircraftState>(), groundLayout: null, new Random(1));
+
+        Assert.Null(error);
+        Assert.NotNull(state);
+        Assert.Equal("01R", state!.Procedure.DestinationRunway);
     }
 }


### PR DESCRIPTION
Fixes #273.

## Problem

A STAR issued or spawned with a **single-digit runway transition** (e.g. `JARR BDEGA 1R`, runways 01–09) silently dropped the CIFP runway-transition legs. The runway designator was carried unpadded, and every runway-transition lookup built its dictionary key as `"RW" + designator`, so `"RW1R"` never matched the zero-padded CIFP key `"RW01R"`. The zero-padded form (`01R`) worked.

## Root cause

`AircraftProcedure.DestinationRunway` is a raw string with no padding invariant (unlike `RunwayInfo.Designator`, which zero-pads on `init`). It is written unpadded from the JARR runway-transition arg (`NavigationCommandHandler`) and from the scenario `StarRunway` (`AircraftGenerator`, via `SpawnParser`, which only uppercases). That unpadded value then reached the `"RW" + designator` lookups.

## Fix

Three layers:

**1. Normalize at the lookups** — zero-pad via `RunwayIdentifier.NormalizeDesignator(...)` before building the `"RW"` key at the three reachable-with-unpadded-input sites:
- `NavigationCommandHandler.LookupRunwayTransition` — the flown-route path (`TryResolveStarFromCifp`).
- `NavigationDatabase.GetStarRunwayTransitions` — radar programmed-fix highlighting.
- `ArrivalRouteResolver.TryLookupRunwayTransition` — scenario-spawn STAR route and restrictions.

**2. Normalize at the source** — pad `DestinationRunway` at its two write sites (`NavigationCommandHandler` JARR arg, `AircraftGenerator` spawn) so the field carries the same padded form as `RunwayInfo.Designator`, closing the class against future consumers rather than only today's lookups.

**3. Client parallel path** — `ShownRouteBuilder.MatchRunwayTransitionKey` (the "Show nav route" STAR/SID vector-tail overlay) used a loose `EndsWith` fallback that resolved single-digit runways only by coincidence and was ambiguous — a bare `"1R"` also matched `RW11R`/`RW31R`. Replaced with normalize-then-exact matching plus the CIFP `RW01B` both-key fallback, mirroring the server helper.

The SID runway-transition sites are left as-is: `DepartureClearanceHandler` receives `AssignedRunway.Designator`, and `NavigationCommandHandler.OverlaySidRestrictions` reads `Procedure.DepartureRunway` — both are always zero-padded (every `DepartureRunway` setter assigns a `RunwayInfo.Designator`), so neither is reachable with unpadded input.

## Verification

- `StarSingleDigitRunwayTransitionTests` reproduces the bug against **real bundled CIFP data** (KSFO BDEGA `RW01R`: BDEGA → CORKK → BRIXX) — the lookup and spawn tests fail on `main`, pass here.
- New TDD tests, each confirmed red→green: JARR and scenario-spawn store a padded `DestinationRunway`; the client overlay resolves `RW01R` for `"1R"` and does not suffix-match `RW31R`.
- `dotnet build -p:TreatWarningsAsErrors=true` → 0 warnings.
- `pwsh tools/test-all.ps1` (both repos): Sim 7166, Client 1152, Client.UI 223, Server 1318 — 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
