### PR TITLE
fix: latch trailing blocks behind a current-block WAIT (#294)

### DIFF
--- a/src/Yaat.Sim/FlightPhysics.cs
+++ b/src/Yaat.Sim/FlightPhysics.cs
@@ -1205,7 +1205,58 @@ public static class FlightPhysics
             }
 
             // Apply the block's commands (a triggered WAIT holds the payload until its countdown elapses).
-            ApplyOrCountdownWait(aircraft, block, deltaSeconds);
+            if (!ApplyOrCountdownWait(aircraft, block, deltaSeconds))
+            {
+                // The current block is a WAIT still counting down. Latch the triggers of the following
+                // `;`-sequenced blocks now (without applying them) so a ReachFix trigger survives the
+                // aircraft flying past the fix during the countdown — otherwise the trailing block orphans
+                // when the queue finally advances to it. Mirrors the holdApplies latching in
+                // ApplyReadyConditionalBlocks, which only covers the lookahead (current-block-applied) path.
+                LatchFollowingTriggers(aircraft, queue, queue.CurrentBlockIndex + 1, aircraftLookup);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Latches (but does not apply) the triggers of the contiguous run of conditional blocks starting at
+    /// <paramref name="startIndex"/>. Used while a current-block WAIT counts down so a trailing block's
+    /// <see cref="BlockTriggerType.ReachFix"/> trigger stays met even after the aircraft flies past the fix.
+    /// Stops at the first unapplied untriggered block so ordinary `;` sequencing is preserved.
+    /// </summary>
+    private static void LatchFollowingTriggers(
+        AircraftState aircraft,
+        CommandQueue queue,
+        int startIndex,
+        Func<string, AircraftState?>? aircraftLookup
+    )
+    {
+        for (int i = startIndex; i < queue.Blocks.Count; i++)
+        {
+            var block = queue.Blocks[i];
+            if (block.IsApplied)
+            {
+                continue;
+            }
+
+            if (block.Trigger is null)
+            {
+                break;
+            }
+
+            if (!block.TriggerMet)
+            {
+                block.TriggerMet = IsTriggerMet(aircraft, block, aircraftLookup);
+                if (!block.TriggerMet)
+                {
+                    TrackFrdMiss(aircraft, block);
+                    continue;
+                }
+
+                if (block.Trigger.Type is BlockTriggerType.OnHandoff)
+                {
+                    aircraft.Track.HandoffAccepted = false;
+                }
+            }
         }
     }
 

--- a/tests/Yaat.Sim.Tests/ConditionWaitDelayTests.cs
+++ b/tests/Yaat.Sim.Tests/ConditionWaitDelayTests.cs
@@ -252,4 +252,71 @@ public class ConditionWaitDelayTests
         Assert.True(waitApplied, "WAIT payload never fired");
         Assert.True(laterApplied, "Later block never fired after the WAIT completed");
     }
+
+    [Fact]
+    public void CurrentBlockWait_HoldsPayload_AndSequencesLaterBlockAfterWait()
+    {
+        var ac = MakeAircraft();
+
+        // Same as the lookahead case but WITHOUT a leading perpetual Navigation block, so the wait
+        // block is the queue's *current* (advancing) block (index 0) rather than reached via lookahead.
+        // This is the non-CFIX shape `AT FIX WAIT 30 CMD1; AT FIX CMD2` given to a vectored aircraft
+        // whose FIX trigger fires by proximity (IsTriggerMet), not by route-sequencing.
+        var trigger = new BlockTrigger
+        {
+            Type = BlockTriggerType.ReachFix,
+            FixLat = ac.Position.Lat,
+            FixLon = ac.Position.Lon,
+        };
+        bool waitApplied = false;
+        bool laterApplied = false;
+        var waitBlock = new CommandBlock
+        {
+            Trigger = trigger,
+            Commands = [new TrackedCommand { Type = TrackedCommandType.Immediate }],
+            IsWaitBlock = true,
+            WaitRemainingSeconds = 30,
+            ApplyAction = _ =>
+            {
+                waitApplied = true;
+                return new CommandResult(true);
+            },
+        };
+        var laterBlock = new CommandBlock
+        {
+            Trigger = new BlockTrigger
+            {
+                Type = BlockTriggerType.ReachFix,
+                FixLat = ac.Position.Lat,
+                FixLon = ac.Position.Lon,
+            },
+            Commands = [new TrackedCommand { Type = TrackedCommandType.Immediate }],
+            ApplyAction = _ =>
+            {
+                laterApplied = true;
+                return new CommandResult(true);
+            },
+        };
+        ac.Queue.Blocks.Add(waitBlock);
+        ac.Queue.Blocks.Add(laterBlock);
+
+        // 10 s in: the wait is still counting down. Neither may have fired.
+        for (int i = 0; i < 10; i++)
+        {
+            FlightPhysics.Update(ac, 1.0, null, null);
+        }
+
+        Assert.False(waitApplied, "WAIT payload fired before its delay elapsed");
+        Assert.False(laterApplied, "Later `;`-sequential block fired before the WAIT completed");
+
+        // Past 30 s total — the wait payload fires, then the later block, which must NOT orphan even
+        // though the aircraft has flown well past the trigger fix during the wait countdown.
+        for (int i = 0; i < 25; i++)
+        {
+            FlightPhysics.Update(ac, 1.0, null, null);
+        }
+
+        Assert.True(waitApplied, "WAIT payload never fired");
+        Assert.True(laterApplied, "Later block orphaned: never fired after the WAIT completed (aircraft passed the fix during the countdown)");
+    }
 }


### PR DESCRIPTION
Fixes #294.

## Problem

The #286 fix added trigger-**latching** so a `;`-sequenced block held behind a post-trigger `WAIT` survives the aircraft flying past its trigger fix. That latch landed on the lookahead and active-phase paths of `UpdateCommandQueue`, but **not** the current-block path (`FlightPhysics.cs:1189-1209`). When a `WAIT` is the queue's current (advancing) block and a following `;`-block shares a `ReachFix` trigger, the trailing block **orphaned**: once the aircraft flew past the fix during the countdown, `IsTriggerMet` returned `false` when the queue finally advanced to it, so it never fired.

Narrow in practice — the common `CFIX … ; AT fix WAIT n … ; RNS` shape pins index 0 with a perpetual Navigation block (lookahead path, already fixed) and route-sequences the fix (`NotifyFixSequenced`, already fixed). It surfaces with the non-CFIX shape `AT FIX WAIT n CMD1; AT FIX CMD2` on a vectored (proximity-triggered) aircraft.

## Fix

While the current-block `WAIT` counts down, latch the following blocks' triggers without applying them, via a small `LatchFollowingTriggers` helper that mirrors the `holdApplies` latch in `ApplyReadyConditionalBlocks`. A dedicated helper (rather than delegating to `ApplyReadyConditionalBlocks`) avoids the `Trigger is null` early-`break` that would skip applying an unconditional current block.

## Test

Adds `CurrentBlockWait_HoldsPayload_AndSequencesLaterBlockAfterWait` (mirrors the existing lookahead test, minus the pinning Navigation block). It fails on `main` (`laterApplied == false`) and passes with the fix. All 42 wait / on-handoff / issue-286 tests stay green; `Yaat.Sim` builds clean under `-p:TreatWarningsAsErrors=true`.

**Confidence:** high on fix correctness (mirrors existing validated latching); medium on real-world reachability of the bug (uncommon command shape). Draft for maintainer review since it touches core command-queue sequencing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
