### PR TITLE
fix: pre-arm multi-modifier compound behind a queued pattern entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- A compound of only pattern modifiers (e.g. `EXT DOWNWIND; SA`) issued while a pattern entry is still queued behind another command no longer silently wipes the queued entry — it now pre-arms each modifier and preserves the entry, matching the single-modifier behavior. Previously the multi-modifier compound dropped the queued entry and failed with "no upcoming downwind leg to extend".
+
 ## v0.9.9-beta [2026/07/14]
 
 ### Highlights

--- a/src/Yaat.Sim/Commands/CommandDispatcher.cs
+++ b/src/Yaat.Sim/Commands/CommandDispatcher.cs
@@ -94,13 +94,17 @@ public static class CommandDispatcher
             return ApplyTransparentCompound(compound, aircraft, ctx);
         }
 
-        // A standalone pattern modifier (EXT / SA / MNA) on an aircraft with no active phase must
-        // apply directly, without the None-dimension ClearConflictingBlocks fast path — which would
-        // otherwise wipe a queued pattern entry (e.g. an ERD sitting behind DCT VPCOL) the moment
-        // the modifier's dispatcher arm makes dry-run succeed. ApplyCommand pre-arms the queued
-        // entry so the modifier fires when it builds its circuit. With an active phase the phase-gate
-        // path below already applies these in place without a queue wipe.
-        if (aircraft.Phases?.CurrentPhase is null && compound.Blocks is [{ } soloBlock] && IsImmediatePhaseModifierBlock(soloBlock))
+        // Standalone pattern modifiers (EXT / SA / MNA) on an aircraft with no active phase must
+        // apply directly, without the All/None-dimension ClearConflictingBlocks fast path — which
+        // would otherwise wipe a queued pattern entry (e.g. an ERD sitting behind DCT VPCOL) the
+        // moment the modifiers' dispatcher arms make dry-run succeed. ApplyCommand pre-arms the
+        // queued entry so each modifier fires when it builds its circuit. This covers both a lone
+        // modifier and a compound of only modifiers (e.g. "EXT DOWNWIND; SA"): a multi-block
+        // modifier compound skips the single-block guard, dry-run validates only its first block,
+        // and the fast-path wipe then destroys the queued entry — so the command fails ("no
+        // upcoming downwind leg to extend") while having already silently dropped the entry. With
+        // an active phase the phase-gate path below already applies these in place without a wipe.
+        if (aircraft.Phases?.CurrentPhase is null && compound.Blocks.Count > 0 && compound.Blocks.All(IsImmediatePhaseModifierBlock))
         {
             return ApplyTransparentCompound(compound, aircraft, ctx);
         }

--- a/tests/Yaat.Sim.Tests/Simulation/QueuedPatternModifierTests.cs
+++ b/tests/Yaat.Sim.Tests/Simulation/QueuedPatternModifierTests.cs
@@ -200,6 +200,53 @@ public class QueuedPatternModifierTests(ITestOutputHelper output)
         Assert.True(downwind.IsExtended);
     }
 
+    /// <summary>
+    /// Regression: a compound of two bare pattern modifiers (e.g. <c>EXT DOWNWIND; SA</c>) issued
+    /// while an ERD sits queued must be accepted and must NOT wipe the queued ERD. Before the fix
+    /// the multi-block compound skipped the single-block reroute, dry-run validated only its first
+    /// block (which now succeeds via the a1cbf22 ApplyCommand arm), and the All-dimension
+    /// queue-clear fast path then silently dropped the queued ERD — so the command failed ("no
+    /// upcoming downwind leg to extend") having already destroyed the entry. The last-armed
+    /// modifier wins (single <c>PendingEntryModifier</c> slot), matching what issuing the two
+    /// modifiers as separate single-block commands already does.
+    /// </summary>
+    [Fact]
+    public void MultiBlockModifier_BehindQueuedErd_IsAcceptedAndPreservesEntry()
+    {
+        var engine = BuildEngine();
+        if (engine is null)
+        {
+            return;
+        }
+
+        SpawnAirborneOverOak(engine, "TST007");
+
+        Assert.True(engine.SendCommand("TST007", "DCT VPCOL; ERD 28R").Success);
+
+        var ac = engine.FindAircraft("TST007");
+        Assert.NotNull(ac);
+        Assert.Contains(ac.Queue.Blocks, b => !b.IsApplied); // queued ERD before
+
+        var mod = engine.SendCommand("TST007", "EXT DOWNWIND; SA");
+        output.WriteLine($"EXT DOWNWIND; SA: success={mod.Success} — {mod.Message}");
+        Assert.True(mod.Success, $"A compound of only pattern modifiers behind a queued ERD should be accepted: {mod.Message}");
+
+        ac = engine.FindAircraft("TST007");
+        Assert.NotNull(ac);
+        Assert.Null(ac.Phases?.CurrentPhase); // still en route — modifiers did not force a phase
+        Assert.Contains(ac.Queue.Blocks, b => !b.IsApplied); // queued ERD NOT wiped
+
+        // Fire the entry: the pre-armed modifier is consumed as the circuit builds.
+        Assert.True(engine.SendCommand("TST007", "ERD 28R").Success);
+
+        ac = engine.FindAircraft("TST007");
+        Assert.NotNull(ac);
+        Assert.NotNull(ac.Phases);
+        var downwind = ac.Phases.Phases.OfType<DownwindPhase>().FirstOrDefault();
+        Assert.NotNull(downwind);
+        Assert.True(downwind.ShortApproachArmed, "The last-armed modifier (SA) must arm the downwind the entry builds");
+    }
+
     private static void SpawnAirborneOverOak(SimulationEngine engine, string callsign)
     {
         // A few miles east of OAK 28R on the right downwind side, slow VFR piston.


### PR DESCRIPTION
Fixes #296.

## Problem

A compound of **two-or-more** bare pattern modifiers (`EXT`/`SA`/`MNA`) issued to an aircraft with **no active phase**, while a pattern entry (`ERD`/`ELD`/…) sits **queued but unfired**, silently **wiped the queued entry** and then reported failure — a regression from a1cbf22, whose protective reroute only covered the *single-block* case.

The multi-block compound skipped the single-block guard, `DryRunValidate` validated only the first block (which now succeeds via a1cbf22's `EXT`/`SA`/`MNA` arm), and the `All`-dimension `ClearConflictingBlocks` fast path then wiped the queued entry. `ApplyBlock(EXT)` ran against the now-empty queue and failed (`"No upcoming downwind leg to extend"`) — the command failed having already destroyed the entry. See #296 for the full trace.

## Fix

Widen the guard in `DispatchCompoundCore` to reroute **any** compound composed entirely of immediate phase modifiers through `ApplyTransparentCompound` (which touches neither the queue nor phases), so each modifier pre-arms the queued entry:

```csharp
if (aircraft.Phases?.CurrentPhase is null && compound.Blocks.Count > 0 && compound.Blocks.All(IsImmediatePhaseModifierBlock))
    return ApplyTransparentCompound(compound, aircraft, ctx);
```

`IsImmediatePhaseModifierBlock` already rejects conditional / multi-command blocks, so conditional-led compounds remain on the additive `IsConditionalIncoming` path. The last-armed modifier wins (single `PendingEntryModifier` slot) — identical to issuing the two modifiers as separate single-block commands.

## Verification

- New regression test `MultiBlockModifier_BehindQueuedErd_IsAcceptedAndPreservesEntry` fails on `main`, passes here.
- `dotnet build src/Yaat.Sim ... -p:TreatWarningsAsErrors=true` → 0 warnings.
- `QueuedPatternModifierTests` (7/7) pass; broader Pattern/Dispatch/CommandHandler sweep (846 tests) green.
- No `Yaat.Sim` signature change → yaat-server unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
