### PR TITLE
fix: IFR go-around no longer auto-enters the VFR pattern (#321)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- An IFR aircraft that goes around no longer flies a VFR traffic pattern circuit when it was given `MLT`/`MRT` earlier in the session; it climbs runway heading and waits for instructions.
+
 ## v0.10.2-beta [2026/07/31]
 
 ### Highlights

--- a/docs/phases.md
+++ b/docs/phases.md
@@ -80,9 +80,11 @@ These run inside `PhaseRunner` after the current phase advances. They turn one-s
 - **Post-LAHSO**: When `LandingPhase.StoppedForLahso` is set, append `RunwayHoldingPhase → RunwayExitPhase → HoldingAfterExitPhase`.
 - **Post-landing (no pattern)**: If queue is complete and `TrafficDirection is null`, auto-append `RunwayExitPhase → HoldingAfterExitPhase`.
 - **Pattern re-entry from go-around**: After `GoAroundPhase` with `ReenterPattern=true`, set `TrafficDirection` from the persistent `AircraftPattern.TrafficDirection` (falling back to the transient field, then Left) when a runway is assigned.
-- **Pattern auto-cycle**: If queue is complete AND `TrafficDirection is not null` AND `AssignedRunway is not null`, `PatternBuilder` builds the next circuit and appends the leg phases. Landing clearance is cleared.
+- **Pattern auto-cycle**: If the completed phase was a cycle terminator (`TouchAndGoPhase`, `StopAndGoPhase`, `LowApproachPhase`) or a `GoAroundPhase` with `ReenterPattern=true`, AND the queue is complete AND a direction resolves (persistent `AircraftPattern.TrafficDirection`, else the transient `TrafficDirection`) AND `AssignedRunway is not null`, `PatternBuilder` builds the next circuit and appends the leg phases. Landing clearance is cleared.
 
 Full-stop approaches **do not** auto-cycle. The pattern bit (`TrafficDirection`) is what distinguishes a touch-and-go aircraft from a full-stop arrival.
+
+The terminator-type gate matters independently of the direction: an instrument go-around leaves `ReenterPattern=false`, and the persistent `AircraftPattern.TrafficDirection` survives `FH`/`TR`/`TL` phase clears, so without it a stale `MLT`/`MRT` would crank an IFR missed approach into a VFR circuit. `PatternCommandHandler.WillAppendNextCircuit` (which `EXT` uses to decide whether to pre-arm `ExtendNextUpwind`) mirrors this gate — keep the two in sync.
 
 ## `PhaseContext` — `Phases/PhaseContext.cs`
 

--- a/src/Yaat.Sim/Phases/PhaseRunner.cs
+++ b/src/Yaat.Sim/Phases/PhaseRunner.cs
@@ -38,7 +38,12 @@ public static class PhaseRunner
         {
             bool wasFullStopTerminator = current is LandingPhase or HelicopterLandingPhase;
             bool wasCycleTerminator = current is TouchAndGoPhase or StopAndGoPhase or LowApproachPhase;
-            bool wasGoAround = current is GoAroundPhase;
+            // Only a go-around that re-enters the pattern arms the auto-cycle. An instrument go-around
+            // (ReenterPattern=false) flies runway heading to 2000 AGL and awaits instructions — it must
+            // NOT auto-enter the pattern even if a stale persistent Pattern.TrafficDirection (from an
+            // earlier MLT/MRT that survived a vector) is still set. See ResolvePatternIntent, which
+            // returns null for a non-in-pattern IFR aircraft precisely to prevent this.
+            bool wasPatternGoAround = current is GoAroundPhase { ReenterPattern: true };
 
             // Stamp landing timestamp on approach score
             if (wasFullStopTerminator && aircraft.ActiveApproachScore is { } landingScore && landingScore.LandedAtSeconds is null)
@@ -117,7 +122,7 @@ public static class PhaseRunner
             // pattern. The persistent direction (MLT/MRT) wins so a single-approach
             // ERB/ELB doesn't redefine the pattern direction for subsequent circuits.
             if (
-                (wasCycleTerminator || wasGoAround)
+                (wasCycleTerminator || wasPatternGoAround)
                 && phases.IsComplete
                 && (persistentDir ?? phases.TrafficDirection) is { } dir
                 && phases.AssignedRunway is not null

--- a/tests/Yaat.Sim.Tests/Issue321IfrGoAroundAutoCycleTests.cs
+++ b/tests/Yaat.Sim.Tests/Issue321IfrGoAroundAutoCycleTests.cs
@@ -10,22 +10,21 @@ using Yaat.Sim.Tests.Helpers;
 namespace Yaat.Sim.Tests;
 
 /// <summary>
-/// Nightly-review repro: an IFR go-around must NOT auto-enter the VFR traffic pattern.
+/// Issue #321: an IFR go-around must not auto-enter the VFR traffic pattern. Instrument approach
+/// traffic flies runway heading to 2000 ft AGL and awaits instructions (AIM 5-4-21);
+/// <see cref="GoAroundHelper.ResolvePatternIntent"/> encodes that by returning null for a
+/// non-in-pattern IFR aircraft, so the resulting <see cref="GoAroundPhase"/> has ReenterPattern=false.
 ///
-/// Contract (docs/phases.md and the comment at PhaseRunner.cs:105): "Instrument approach traffic
-/// does NOT auto-enter the pattern — they fly runway heading to 2000 AGL and await instructions."
-/// <see cref="GoAroundHelper.ResolvePatternIntent"/> enforces this by returning null for a non-in-pattern
-/// IFR aircraft, so the resulting <see cref="GoAroundPhase"/> has ReenterPattern=false.
-///
-/// But the persistent <see cref="AircraftPattern.TrafficDirection"/> (set by an earlier MLT/MRT and
-/// deliberately surviving FH/TR/TL phase clears) is read by PhaseRunner's auto-cycle guard WITHOUT
-/// checking ReenterPattern, so a completed IFR go-around is cranked into a full VFR circuit anyway.
+/// PhaseRunner's auto-cycle guard used to fire on any completed go-around without checking
+/// ReenterPattern, so an aircraft still carrying a persistent <see cref="AircraftPattern.TrafficDirection"/>
+/// (stamped by an earlier MLT/MRT, which deliberately survives FH/TR/TL phase clears) was cranked
+/// into a full VFR circuit off an instrument missed approach.
 /// </summary>
-public class NightlyReviewIfrGoAroundAutoCycleTests
+public class Issue321IfrGoAroundAutoCycleTests
 {
     private readonly ITestOutputHelper _output;
 
-    public NightlyReviewIfrGoAroundAutoCycleTests(ITestOutputHelper output)
+    public Issue321IfrGoAroundAutoCycleTests(ITestOutputHelper output)
     {
         _output = output;
         TestVnasData.EnsureInitialized();
@@ -82,10 +81,8 @@ public class NightlyReviewIfrGoAroundAutoCycleTests
         // post-completion routing.
         PhaseRunner.Tick(aircraft, ctx);
 
-        var appendedPatternLegs = aircraft.Phases?.Phases.Where(p =>
-            p is UpwindPhase or CrosswindPhase or DownwindPhase or BasePhase or PatternEntryPhase
-        )
-            .ToList() ?? new List<Phase>();
+        var appendedPatternLegs =
+            aircraft.Phases?.Phases.Where(p => p is UpwindPhase or CrosswindPhase or DownwindPhase or BasePhase or PatternEntryPhase).ToList() ?? [];
 
         foreach (var leg in appendedPatternLegs)
         {
@@ -141,10 +138,7 @@ public class NightlyReviewIfrGoAroundAutoCycleTests
         aircraft.Phases.Start(ctx);
         PhaseRunner.Tick(aircraft, ctx);
 
-        var appendedPatternLegs = aircraft.Phases?.Phases.Where(p =>
-            p is UpwindPhase or CrosswindPhase or DownwindPhase or BasePhase
-        )
-            .ToList() ?? new List<Phase>();
+        var appendedPatternLegs = aircraft.Phases?.Phases.Where(p => p is UpwindPhase or CrosswindPhase or DownwindPhase or BasePhase).ToList() ?? [];
 
         Assert.True(appendedPatternLegs.Count > 0, "A VFR pattern go-around should auto-enter the pattern.");
     }

--- a/tests/Yaat.Sim.Tests/NightlyReviewIfrGoAroundAutoCycleTests.cs
+++ b/tests/Yaat.Sim.Tests/NightlyReviewIfrGoAroundAutoCycleTests.cs
@@ -1,0 +1,151 @@
+using Xunit;
+using Xunit.Abstractions;
+using Yaat.Sim.Commands;
+using Yaat.Sim.Data;
+using Yaat.Sim.Phases;
+using Yaat.Sim.Phases.Pattern;
+using Yaat.Sim.Phases.Tower;
+using Yaat.Sim.Tests.Helpers;
+
+namespace Yaat.Sim.Tests;
+
+/// <summary>
+/// Nightly-review repro: an IFR go-around must NOT auto-enter the VFR traffic pattern.
+///
+/// Contract (docs/phases.md and the comment at PhaseRunner.cs:105): "Instrument approach traffic
+/// does NOT auto-enter the pattern — they fly runway heading to 2000 AGL and await instructions."
+/// <see cref="GoAroundHelper.ResolvePatternIntent"/> enforces this by returning null for a non-in-pattern
+/// IFR aircraft, so the resulting <see cref="GoAroundPhase"/> has ReenterPattern=false.
+///
+/// But the persistent <see cref="AircraftPattern.TrafficDirection"/> (set by an earlier MLT/MRT and
+/// deliberately surviving FH/TR/TL phase clears) is read by PhaseRunner's auto-cycle guard WITHOUT
+/// checking ReenterPattern, so a completed IFR go-around is cranked into a full VFR circuit anyway.
+/// </summary>
+public class NightlyReviewIfrGoAroundAutoCycleTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public NightlyReviewIfrGoAroundAutoCycleTests(ITestOutputHelper output)
+    {
+        _output = output;
+        TestVnasData.EnsureInitialized();
+    }
+
+    private static RunwayInfo? Runway(string designator) => NavigationDatabase.Instance.GetRunway("OAK", designator);
+
+    [Fact]
+    public void IfrGoAround_WithStalePersistentPatternDirection_DoesNotAutoEnterPattern()
+    {
+        var runway = Runway("28R");
+        if (runway is null)
+        {
+            return;
+        }
+
+        // IFR aircraft, already climbed through 2000 ft AGL so the self-clearing go-around completes
+        // on the first PhaseRunner tick.
+        var aircraft = new AircraftState
+        {
+            Callsign = "N85439",
+            AircraftType = "C172",
+            AirportId = "OAK",
+            Position = new LatLon(runway.ThresholdLatitude, runway.ThresholdLongitude),
+            TrueHeading = runway.TrueHeading,
+            Altitude = runway.ElevationFt + 2500,
+            IndicatedAirspeed = 90,
+            IsOnGround = false,
+            FlightPlan = new AircraftFlightPlan { FlightRules = "IFR", Destination = "KOAK" },
+        };
+
+        // A prior MLT stamped the persistent pattern direction; it survives a subsequent vector / new
+        // approach clearance (Pattern.TrafficDirection is only cleared by CLAND/LAHSO/force-landing).
+        aircraft.Pattern.TrafficDirection = PatternDirection.Left;
+
+        // The go-around GoAroundHelper.Trigger builds for a non-in-pattern IFR aircraft: no MAP data,
+        // so it self-clears at 2000 AGL and is the last phase. phases.TrafficDirection stays null.
+        aircraft.Phases = new PhaseList { AssignedRunway = runway };
+        aircraft.Phases.Add(
+            new GoAroundPhase
+            {
+                ReenterPattern = false,
+                TargetAltitude = null,
+                NextLandingFullStop = true,
+            }
+        );
+
+        var ctx = CommandDispatcher.BuildMinimalContext(aircraft, groundLayout: null);
+        aircraft.Phases.Start(ctx);
+        Assert.IsType<GoAroundPhase>(aircraft.Phases.CurrentPhase);
+        Assert.Null(aircraft.Phases.TrafficDirection);
+
+        // One tick: the go-around is already above 2000 AGL, so it completes and PhaseRunner runs its
+        // post-completion routing.
+        PhaseRunner.Tick(aircraft, ctx);
+
+        var appendedPatternLegs = aircraft.Phases?.Phases.Where(p =>
+            p is UpwindPhase or CrosswindPhase or DownwindPhase or BasePhase or PatternEntryPhase
+        )
+            .ToList() ?? new List<Phase>();
+
+        foreach (var leg in appendedPatternLegs)
+        {
+            _output.WriteLine($"WRONGLY appended pattern leg: {leg.GetType().Name}");
+        }
+
+        Assert.True(
+            appendedPatternLegs.Count == 0,
+            $"An IFR go-around (ReenterPattern=false) must not auto-enter the pattern, but PhaseRunner "
+                + $"appended {appendedPatternLegs.Count} pattern leg(s): {string.Join(", ", appendedPatternLegs.Select(p => p.GetType().Name))}"
+        );
+    }
+
+    /// <summary>
+    /// Control: a VFR aircraft with the same persistent direction SHOULD re-enter the pattern
+    /// (ResolvePatternIntent returns the direction → ReenterPattern=true). This pins the intended
+    /// behavior so the fix only suppresses the IFR case.
+    /// </summary>
+    [Fact]
+    public void VfrGoAround_WithPersistentPatternDirection_DoesAutoEnterPattern()
+    {
+        var runway = Runway("28R");
+        if (runway is null)
+        {
+            return;
+        }
+
+        var aircraft = new AircraftState
+        {
+            Callsign = "N123AB",
+            AircraftType = "C172",
+            AirportId = "OAK",
+            Position = new LatLon(runway.ThresholdLatitude, runway.ThresholdLongitude),
+            TrueHeading = runway.TrueHeading,
+            Altitude = runway.ElevationFt + 2500,
+            IndicatedAirspeed = 90,
+            IsOnGround = false,
+            FlightPlan = new AircraftFlightPlan { FlightRules = "VFR", Destination = "KOAK" },
+        };
+        aircraft.Pattern.TrafficDirection = PatternDirection.Left;
+
+        aircraft.Phases = new PhaseList { AssignedRunway = runway, TrafficDirection = PatternDirection.Left };
+        aircraft.Phases.Add(
+            new GoAroundPhase
+            {
+                ReenterPattern = true,
+                TargetAltitude = null,
+                NextLandingFullStop = false,
+            }
+        );
+
+        var ctx = CommandDispatcher.BuildMinimalContext(aircraft, groundLayout: null);
+        aircraft.Phases.Start(ctx);
+        PhaseRunner.Tick(aircraft, ctx);
+
+        var appendedPatternLegs = aircraft.Phases?.Phases.Where(p =>
+            p is UpwindPhase or CrosswindPhase or DownwindPhase or BasePhase
+        )
+            .ToList() ?? new List<Phase>();
+
+        Assert.True(appendedPatternLegs.Count > 0, "A VFR pattern go-around should auto-enter the pattern.");
+    }
+}


### PR DESCRIPTION
Fixes #321.

## Problem

`PhaseRunner`'s post-completion auto-cycle fired on **any** completed `GoAroundPhase` (`wasGoAround`) without checking `ReenterPattern`. An **IFR** go-around — which `GoAroundHelper.Trigger` builds with `ReenterPattern=false` and no `phases.TrafficDirection` — was cranked into a full VFR circuit whenever the aircraft still carried a stale persistent `Pattern.TrafficDirection` (set by an earlier `MLT`/`MRT` and deliberately surviving `FH`/`TR`/`TL` clears). That contradicts the in-code contract at `PhaseRunner.cs:105` ("Instrument approach traffic does NOT auto-enter the pattern") and AIM 5-4-21.

## Fix

Gate the go-around disjunct on `ReenterPattern:true`, mirroring the pattern re-stamp just above it:

```csharp
bool wasPatternGoAround = current is GoAroundPhase { ReenterPattern: true };
...
if ((wasCycleTerminator || wasPatternGoAround) && phases.IsComplete && ...)
```

VFR/pattern and `MLT`-during-go-around paths set `ReenterPattern=true`, so they are unaffected.

## Verification

- New `NightlyReviewIfrGoAroundAutoCycleTests`: the IFR case (fails on `main`) now passes; a VFR control test pins that the pattern go-around still auto-enters.
- 766 existing pattern / phase / auto-cycle / `PhaseAcceptanceAudit` tests pass.
- Clean `dotnet build src/Yaat.Sim -p:TreatWarningsAsErrors=true` (0 warnings).

Confidence: medium (the logic gap + fix are test-verified; the trigger needs the specific but unblocked IFR + persistent-pattern-direction chain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
