### PR TITLE
fix: allow the §5-9-1 45° helicopter intercept angle (#330)

### DIFF
--- a/src/Yaat.Sim/Phases/Approach/InterceptCoursePhase.cs
+++ b/src/Yaat.Sim/Phases/Approach/InterceptCoursePhase.cs
@@ -48,6 +48,12 @@ public sealed partial class InterceptCoursePhase : Phase
     private const double SpeedAnticipationThresholdNm = 2.0;
     private const double InterceptSpeedFasMultiplier = 1.3;
     private const double BustThroughAlignmentDeg = 30.0;
+
+    // 7110.65 §5-9-2 TBL 5-9-1: the max interception angle at 2 mi or more from the gate is 30°,
+    // "45 degrees for helicopters" — a helicopter can turn tight enough to capture a steeper cut, so
+    // it must not be refused at the 30° jet gate.
+    private const double HelicopterBustThroughAlignmentDeg = 45.0;
+
     private const double MaxElapsedSeconds = 180.0;
 
     private double? _previousSignedCrossTrack;
@@ -103,7 +109,8 @@ public sealed partial class InterceptCoursePhase : Phase
         // gate is effectively unbounded (180° is the theoretical maximum between two headings).
         // The bust-through branch at the centerline-crossing check becomes unreachable, so the
         // aircraft always joins the localizer regardless of how steep the cut is.
-        double maxAlignmentDeg = (ForcedIntercept || RelaxedJoin) ? 180.0 : BustThroughAlignmentDeg;
+        double categoryGateDeg = ctx.Category == AircraftCategory.Helicopter ? HelicopterBustThroughAlignmentDeg : BustThroughAlignmentDeg;
+        double maxAlignmentDeg = (ForcedIntercept || RelaxedJoin) ? 180.0 : categoryGateDeg;
 
         // For parallel-offset approaches the FAC line does not pass through the runway
         // threshold, so we measure cross-track against the published anchor (e.g. the LDA's

--- a/src/Yaat.Sim/Phases/Tower/FinalApproachPhase.cs
+++ b/src/Yaat.Sim/Phases/Tower/FinalApproachPhase.cs
@@ -1316,7 +1316,10 @@ public sealed class FinalApproachPhase : Phase
         // Approach gate = minIntercept - 2nm (the 2nm padding is from gate to min intercept)
         double approachGate = minIntercept - 2.0;
         double distToGate = captureDistNm - approachGate;
-        double maxAngle = distToGate < 2.0 ? 20.0 : 30.0;
+        // "2 miles or more" allows 30°, or 45° for helicopters (a helicopter can capture a steeper cut).
+        // Inside 2 mi the limit is 20° for every category.
+        double farGateMaxAngle = ctx.Category == AircraftCategory.Helicopter ? 45.0 : 30.0;
+        double maxAngle = distToGate < 2.0 ? 20.0 : farGateMaxAngle;
         bool isAngleLegal = notVectoredToFac || interceptAngle <= maxAngle;
 
         // Glideslope deviation at establishment, against the path this aircraft is actually flying —

--- a/tests/Yaat.Sim.Tests/InterceptHelicopterAngleTests.cs
+++ b/tests/Yaat.Sim.Tests/InterceptHelicopterAngleTests.cs
@@ -1,0 +1,112 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+using Yaat.Sim.Commands;
+using Yaat.Sim.Phases;
+using Yaat.Sim.Phases.Approach;
+using Yaat.Sim.Phases.Tower;
+
+namespace Yaat.Sim.Tests;
+
+/// <summary>
+/// 7110.65 §5-9-2 TBL 5-9-1 allows a final-approach-course interception angle of up to 30° at
+/// 2 mi or more from the approach gate — <b>45° for helicopters</b>. <see cref="InterceptCoursePhase"/>
+/// hard-codes a 30° bust-through gate (<c>BustThroughAlignmentDeg</c>) for every category, so a
+/// helicopter legally vectored to intercept at a 40° cut is wrongly refused ("Unable, passing through
+/// localizer") and the approach is abandoned.
+/// </summary>
+public class InterceptHelicopterAngleTests
+{
+    private const double RunwayHeading = 280.0;
+    private const double ThresholdLat = 37.72;
+    private const double ThresholdLon = -122.22;
+
+    private static AircraftState MakeAircraft(string type, double heading, double lat, double lon) =>
+        new()
+        {
+            Callsign = "N911",
+            AircraftType = type,
+            TrueHeading = new TrueHeading(heading),
+            Altitude = 2000,
+            Position = new LatLon(lat, lon),
+            FlightPlan = new AircraftFlightPlan { Destination = "OAK" },
+        };
+
+    private static PhaseContext MakeContext(AircraftState aircraft, AircraftCategory category) =>
+        new()
+        {
+            Aircraft = aircraft,
+            Targets = aircraft.Targets,
+            Category = category,
+            DeltaSeconds = 1.0,
+            Logger = NullLogger.Instance,
+        };
+
+    private static (AircraftState aircraft, InterceptCoursePhase phase) Setup(string type)
+    {
+        var aircraft = MakeAircraft(type, heading: 240, lat: 37.74, lon: -122.23);
+        aircraft.Phases = new PhaseList
+        {
+            ActiveApproach = new ApproachClearance
+            {
+                ApproachId = "I28R",
+                AirportCode = "OAK",
+                RunwayId = "28R",
+                FinalApproachCourse = new TrueHeading(RunwayHeading),
+            },
+        };
+        var phase = new InterceptCoursePhase
+        {
+            FinalApproachCourse = new TrueHeading(RunwayHeading),
+            ThresholdLat = ThresholdLat,
+            ThresholdLon = ThresholdLon,
+            ApproachId = "I28R",
+            ForcedIntercept = false,
+        };
+        aircraft.Phases.Add(phase);
+        aircraft.Phases.Add(new HelicopterLandingPhase());
+        return (aircraft, phase);
+    }
+
+    /// <summary>
+    /// Helicopter, heading 240 on course 280 = 40° cut. 40° &gt; 30° but 40° ≤ 45°, so per
+    /// TBL 5-9-1 it is a legal helicopter intercept and must CAPTURE, not bust through.
+    /// </summary>
+    [Fact]
+    public void Helicopter_40DegIntercept_CapturesNotBustThrough()
+    {
+        var (aircraft, phase) = Setup("EC45");
+        var ctx = MakeContext(aircraft, AircraftCategory.Helicopter);
+        phase.Status = PhaseStatus.Active;
+        phase.OnStart(ctx);
+
+        phase.OnTick(ctx);
+        aircraft.Position = new LatLon(aircraft.Position.Lat - 0.02, aircraft.Position.Lon - 0.03);
+        bool complete = phase.OnTick(ctx);
+
+        Assert.True(complete);
+        Assert.Empty(aircraft.PendingNotifications);
+        Assert.NotNull(aircraft.Phases!.ActiveApproach);
+    }
+
+    /// <summary>
+    /// Regression guard: the same 40° geometry for a JET must still bust through — the 45°
+    /// allowance is helicopter-only, the 30° gate is unchanged for everyone else.
+    /// </summary>
+    [Fact]
+    public void Jet_40DegIntercept_StillBustsThrough()
+    {
+        var (aircraft, phase) = Setup("B738");
+        var ctx = MakeContext(aircraft, AircraftCategory.Jet);
+        phase.Status = PhaseStatus.Active;
+        phase.OnStart(ctx);
+
+        phase.OnTick(ctx);
+        aircraft.Position = new LatLon(aircraft.Position.Lat - 0.02, aircraft.Position.Lon - 0.03);
+        bool complete = phase.OnTick(ctx);
+
+        Assert.True(complete);
+        Assert.Single(aircraft.PendingNotifications);
+        Assert.Contains("localizer", aircraft.PendingNotifications[0], StringComparison.OrdinalIgnoreCase);
+        Assert.Null(aircraft.Phases!.ActiveApproach);
+    }
+}


### PR DESCRIPTION
Fixes #330.

## What

7110.65 §5-9-2 TBL 5-9-1 caps the final-approach-course interception angle at **30° at 2 mi or more from the gate — "45 degrees for helicopters."** `InterceptCoursePhase` hard-coded a 30° bust-through gate for every category, so a helicopter legally vectored (PTAC/CAPP/JAPP/JFAC all build `InterceptCoursePhase → HelicopterLandingPhase` for rotorcraft) to a 30–45° cut busted through — *"Unable, passing through localizer"* — cleared the approach phases and nulled `ActiveApproach`, abandoning a legal clearance. The same 30°-for-all cap mis-graded helicopter approaches in `ApproachScore`.

## Fix (mechanical, category-aware)

- `InterceptCoursePhase.cs` — new `HelicopterBustThroughAlignmentDeg = 45.0`; the gate picks it for `AircraftCategory.Helicopter`, leaving the 30° gate (and the `ForcedIntercept`/`RelaxedJoin` 180° override) unchanged for everyone else.
- `FinalApproachPhase.cs` — TBL 5-9-1 scoring uses 45° for helicopters at ≥2 mi; the inside-2-mi 20° limit is unchanged for all categories.

Mirrors the existing helicopter-45° envelope already used in pattern entry (`MaxCloseInFinalAngleOffDeg`).

## Verification

- New `tests/Yaat.Sim.Tests/InterceptHelicopterAngleTests.cs` — a helicopter at a 40° cut now **captures** (was: bust-through); a jet control at the identical geometry **still busts through**. Confirmed failing against pre-fix code, passing after.
- `dotnet build src/Yaat.Sim -p:TreatWarningsAsErrors=true` → 0 warnings.
- Intercept + approach-score + final-approach + helicopter + PTAC/CAPP/CVA/JFAC/approach-gate suites: **319 passed, 0 failed.**

Grounded in `.claude/reference/faa/7110.65/chap05_sec09.md` TBL 5-9-1. Aviation-logic change — flagging for `aviation-sim-expert` review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
