### PR TITLE
fix: cancel a queued VFR hold when a lateral vector supersedes it (#336)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- A queued conditional VFR hold (`HPPL`/`HPPR`/`HPP`/`HFIXL`/`HFIXR`/`HFIX`, e.g. `AT 5000 HPPR`) is now cancelled by a superseding vector or direct-to instead of re-entering the orbit once its trigger fires. Altitude and speed assignments still leave the queued hold in place.
+
 ## v0.11.6-beta [2026/08/07]
 
 ### Highlights

--- a/docs/command-handlers.md
+++ b/docs/command-handlers.md
@@ -214,10 +214,10 @@ installs the single fix, and sets a departure heading, so it stays lateral.
 
 **Incoming vs. queued is a different question.** `GetCommandDimension` answers "what does this command seize when it fires" — which is what the
 *incoming* compound is measured by. What a block that is still *waiting in the queue* occupies is `CommandDescriber.GetQueuedCommandDimension`, and
-`SplitBlockNonConflicting`'s per-command keep test must use that one. The two diverge for pattern entries and approach clearances: an incoming `ERD`
-or `CAPP` takes all three axes (so issuing one clears the whole queue), but one sitting behind a `DCT` is only a lateral plan — a fresh vector or DCT
-replaces it and must cancel it, while an altitude or speed assignment issued on the way to the fix must not. Everything else falls through to the
-`TrackedCommandType` classification.
+`SplitBlockNonConflicting`'s per-command keep test must use that one. The two diverge for pattern entries, approach clearances, and holds
+(`CommandDescriber.IsHoldCommand` — `HPP*`/`HFIX*`/`HP`): an incoming `ERD` or `CAPP` takes all three axes (so issuing one clears the whole queue),
+but one sitting behind a `DCT` or `AT` condition is only a lateral plan — a fresh vector or DCT replaces it and must cancel it, while an altitude or
+speed assignment issued on the way to the fix must not. Everything else falls through to the `TrackedCommandType` classification.
 
 > Never call `aircraft.Queue.Clear()` / `aircraft.CommandQueue.Clear()` inside a handler to "reset" state — that defeats parallel-block survival.
 

--- a/src/Yaat.Sim/Commands/CommandDescriber.cs
+++ b/src/Yaat.Sim/Commands/CommandDescriber.cs
@@ -305,12 +305,32 @@ public static class CommandDescriber
     /// </summary>
     internal static CommandDimension GetQueuedCommandDimension(ParsedCommand command)
     {
-        if (IsPatternEntryCommand(command) || IsApproachCommand(command))
+        // Pattern entries, approach clearances, and holds are all "lateral plans" while they wait: a
+        // fresh vector or DCT replaces the plan and must cancel the queued block. The four VFR holds
+        // have no arm in ClassifyCommand (they fall through to Immediate → None), yet GetCommandDimension
+        // classifies them as Lateral — so without this arm a queued hold's aggregate block dimension
+        // reports a lateral conflict while its per-command keep-test reads None, and SplitBlockNonConflicting
+        // keeps (survives) the very hold a superseding vector was meant to cancel.
+        if (IsPatternEntryCommand(command) || IsApproachCommand(command) || IsHoldCommand(command))
         {
             return CommandDimension.Lateral;
         }
 
         return GetDimension(ClassifyCommand(command));
+    }
+
+    /// <summary>
+    /// The hold commands that <see cref="GetCommandDimension"/> classifies as <see cref="CommandDimension.Lateral"/>.
+    /// Kept in sync with that switch arm so a queued hold occupies the same axis it seizes when it fires.
+    /// </summary>
+    internal static bool IsHoldCommand(ParsedCommand command)
+    {
+        return command
+            is HoldPresentPosition360Command
+                or HoldPresentPositionHoverCommand
+                or HoldAtFixOrbitCommand
+                or HoldAtFixHoverCommand
+                or HoldingPatternCommand;
     }
 
     /// <summary>
@@ -368,14 +388,7 @@ public static class CommandDescriber
         }
 
         // Holding patterns are lateral
-        if (
-            command
-            is HoldPresentPosition360Command
-                or HoldPresentPositionHoverCommand
-                or HoldAtFixOrbitCommand
-                or HoldAtFixHoverCommand
-                or HoldingPatternCommand
-        )
+        if (IsHoldCommand(command))
         {
             return CommandDimension.Lateral;
         }

--- a/tests/Yaat.Sim.Tests/QueuedHoldSupersedeTests.cs
+++ b/tests/Yaat.Sim.Tests/QueuedHoldSupersedeTests.cs
@@ -1,0 +1,70 @@
+using Xunit;
+using Yaat.Sim.Commands;
+
+namespace Yaat.Sim.Tests;
+
+/// <summary>
+/// A queued (not-yet-fired) VFR hold — HPPL/HPPR/HPP and the HFIX* fix holds — occupies the
+/// lateral axis while it waits, exactly like a queued pattern entry or approach clearance. A
+/// fresh vector must therefore cancel it (the controller changed the plan before the hold fired).
+///
+/// Regression: <c>CommandDescriber.GetQueuedCommandDimension</c> special-cased pattern entries and
+/// approach clearances to Lateral but left the four VFR hold commands to fall through to
+/// <c>ClassifyCommand</c>, which has no hold arm → <c>Immediate</c> → dimension <c>None</c>. Meanwhile
+/// <c>GetCommandDimension</c> classifies those same holds as Lateral, so the queued block's aggregate
+/// <c>Dimensions</c> reported a lateral conflict while its per-command keep-test read None. In
+/// <c>SplitBlockNonConflicting</c> that means every command index is "kept" and the whole block
+/// survives the supersede — the exact "per-command dims all None while the block reports a conflict
+/// in aggregate" anti-pattern the command-handlers doc warns about (the RELR-20 shape).
+/// </summary>
+public class QueuedHoldSupersedeTests
+{
+    public QueuedHoldSupersedeTests()
+    {
+        TestVnasData.EnsureInitialized();
+    }
+
+    private static AircraftState MakeAircraft()
+    {
+        return new AircraftState
+        {
+            Callsign = "N929AW",
+            AircraftType = "BE33",
+            Position = new LatLon(37.7, -122.2),
+            TrueHeading = new TrueHeading(090),
+            TrueTrack = new TrueHeading(090),
+            Altitude = 3000,
+            IndicatedAirspeed = 120,
+            IsOnGround = false,
+        };
+    }
+
+    private static bool HasQueuedHold(AircraftState ac) =>
+        ac.Queue.Blocks.Any(b => (b.ParsedCommands ?? []).Any(c => c is HoldPresentPosition360Command));
+
+    [Fact]
+    public void FreshVector_CancelsQueuedHoldOrbit()
+    {
+        var ac = MakeAircraft();
+
+        // Queue a conditional hold: when the aircraft reaches 5000 ft, orbit right in place.
+        // (Altitude condition keeps the repro free of any nav-fix lookup.)
+        var holdCompound = CommandParser.ParseCompound("AT 5000 HPPR");
+        Assert.True(holdCompound.IsSuccess, $"Hold parse failed: {holdCompound.Reason}");
+
+        var holdResult = CommandDispatcher.DispatchCompound(holdCompound.Value!, ac, TestDispatch.Context(Random.Shared, validateDctFixes: false));
+        Assert.True(holdResult.Success, $"Hold dispatch failed: {holdResult.Message}");
+        Assert.True(HasQueuedHold(ac), "Precondition: the conditional hold should be sitting in the queue.");
+
+        // Controller changes the plan before the hold fires: a fresh lateral vector.
+        var vectorCompound = CommandParser.ParseCompound("FH 270");
+        Assert.True(vectorCompound.IsSuccess, $"Vector parse failed: {vectorCompound.Reason}");
+
+        var vectorResult = CommandDispatcher.DispatchCompound(vectorCompound.Value!, ac, TestDispatch.Context(Random.Shared, validateDctFixes: false));
+        Assert.True(vectorResult.Success, $"Vector dispatch failed: {vectorResult.Message}");
+
+        // The lateral vector must supersede the queued lateral hold — otherwise, once the aircraft
+        // passes 5000 ft it turns itself back into the orbit the controller just vectored it out of.
+        Assert.False(HasQueuedHold(ac), "The fresh FH vector should have cancelled the queued hold orbit, but it survived in the queue.");
+    }
+}


### PR DESCRIPTION
Fixes #336.

## Problem

A queued (not-yet-fired) VFR hold — `HPPL`/`HPPR`/`HPP` and `HFIXL`/`HFIXR`/`HFIX` — **survived a superseding lateral vector** instead of being cancelled, then re-fired when the aircraft reached the hold's trigger — turning it back into the orbit the controller had just vectored it out of. This is the "per-command dims all `None` while the block reports a conflict in aggregate" anti-pattern `docs/command-handlers.md` warns about (the `RELR 20` shape).

## Root cause

`GetCommandDimension` classifies all five hold commands as `Lateral`, but `GetQueuedCommandDimension` only special-cased pattern entries and approach clearances — the four VFR holds fell through to `ClassifyCommand`, which has no hold arm (→ `Immediate` → `None`). So a queued hold block reported `Dimensions == Lateral` (a lateral conflict) while its per-command keep-test read `None`, and `SplitBlockNonConflicting` kept the whole block.

## Fix

Extend the `GetQueuedCommandDimension` special-case to holds via a shared `IsHoldCommand` helper, also reused by `GetCommandDimension` so the two hold lists can't drift. A queued hold is now cancelled by an incoming lateral vector/DCT but left alone by an altitude/speed assignment — matching the documented intent for pattern entries and approach clearances.

## Verification

- New TDD repro `QueuedHoldSupersedeTests.FreshVector_CancelsQueuedHoldOrbit` fails against `e036fca` and passes with the fix (committed together so the PR is self-verifying).
- Full command/dispatch/queue/pattern/hold/navigation/approach test surface (3604 tests) stays green.
- `dotnet build src/Yaat.Sim -p:TreatWarningsAsErrors=true` is clean (0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
