### PR TITLE
fix: resolve GW give-way alias callsign argument on send

### DIFF
--- a/src/Yaat.Client/Services/CallsignArgumentResolver.cs
+++ b/src/Yaat.Client/Services/CallsignArgumentResolver.cs
@@ -130,7 +130,7 @@ internal static class CallsignArgumentResolver
 
         if (conditionVerb is "GIVEWAY" or "BEHIND")
         {
-            var prefixRewrite = TryRewriteConditionCallsign(prefixText, conditionVerb, aircraft);
+            var prefixRewrite = TryRewriteConditionCallsign(prefixText, aircraft);
             if (prefixRewrite.Error is not null)
             {
                 return new Result(null, prefixRewrite.Error);
@@ -286,12 +286,21 @@ internal static class CallsignArgumentResolver
     /// (e.g. "BEHIND 152SP " → "BEHIND N152SP ") via <see cref="CallsignMatcher"/>.
     /// Trailing whitespace is preserved verbatim.
     ///
+    /// The verb length is measured from the original <paramref name="prefixText"/> (its first
+    /// whitespace-delimited token), not from the normalized condition keyword: the "GW" alias
+    /// normalizes to "GIVEWAY", so using the keyword's length would slice into the callsign token.
+    ///
     /// Returns Text=null when no rewrite was needed; Error non-null on ambiguity.
     /// </summary>
-    private static Result TryRewriteConditionCallsign(string prefixText, string conditionVerb, IReadOnlyCollection<AircraftModel> aircraft)
+    private static Result TryRewriteConditionCallsign(string prefixText, IReadOnlyCollection<AircraftModel> aircraft)
     {
-        int verbLen = conditionVerb.Length;
-        if (prefixText.Length < verbLen + 1)
+        int verbLen = 0;
+        while (verbLen < prefixText.Length && !char.IsWhiteSpace(prefixText[verbLen]))
+        {
+            verbLen++;
+        }
+
+        if (verbLen >= prefixText.Length)
         {
             return new Result(null, null);
         }

--- a/tests/Yaat.Client.Tests/CallsignArgumentResolverTests.cs
+++ b/tests/Yaat.Client.Tests/CallsignArgumentResolverTests.cs
@@ -242,4 +242,24 @@ public class CallsignArgumentResolverTests
         Assert.Null(result.Error);
         Assert.Equal("BEHIND N152SP TAXI C", result.Text);
     }
+
+    [Fact]
+    public void GwAlias_UniqueSubstring_RewritesCallsign()
+    {
+        // "GW" is the short alias for the GIVEWAY condition prefix. Its callsign argument
+        // must resolve exactly like the spelled-out "GIVEWAY 152SP ..." form.
+        var result = CallsignArgumentResolver.TryRewrite("GW 152SP TAXI C", Scheme, Aircraft("N152SP", "N569SX"));
+
+        Assert.Null(result.Error);
+        Assert.Equal("GW N152SP TAXI C", result.Text);
+    }
+
+    [Fact]
+    public void GwAlias_ExactMatch_LeavesUntouched()
+    {
+        var result = CallsignArgumentResolver.TryRewrite("GW N152SP TAXI C", Scheme, Aircraft("N152SP"));
+
+        Assert.Null(result.Error);
+        Assert.Equal("GW N152SP TAXI C", result.Text);
+    }
 }


### PR DESCRIPTION
Fixes #339.

## Problem

The `GW` short alias for the `GIVEWAY` condition prefix corrupts its callsign argument before the command is sent. `CallsignArgumentResolver.TryRewriteConditionCallsign` skipped the verb using `conditionVerb.Length`, but `conditionVerb` is the **normalized** keyword — `StripConditionPrefix` normalizes `GW` → `GIVEWAY`. Since 7 (`"GIVEWAY".Length`) is longer than the real `GW ` prefix (3), the code sliced into the callsign token and rebuilt from the wrong offset:

- `GW 152SP TAXI C` → `GW 152SN152SP TAXI C`
- `GW N152SP TAXI C` (exact) → `GW N152N152SP TAXI C`

The spelled-out `GIVEWAY`/`BEHIND` forms were unaffected (alias == normalized keyword).

## Fix

Measure the verb length from the original `prefixText` (its first whitespace-delimited token) instead of the normalized keyword. Behavior-preserving for `GIVEWAY`/`BEHIND`; fixes `GW`. The now-unused `conditionVerb` parameter is dropped from the method.

## Verification

- Added `GwAlias_UniqueSubstring_RewritesCallsign` and `GwAlias_ExactMatch_LeavesUntouched` — both FAIL against pre-fix code, PASS after.
- All 26 `CallsignArgumentResolverTests` pass.
- `dotnet build src/Yaat.Client -p:TreatWarningsAsErrors=true` → 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)