### PR TITLE
fix: FOLLOWG clears active ground hold so a held follower moves (#348)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Telling a held aircraft to follow another aircraft on the ground (`FOLLOWG` or the Follow… context menu) now releases the hold so it actually moves — previously the command was acknowledged but the aircraft stayed frozen at 0 kt until a `TAXI` or `RES`.
+
 ## v0.12.3-beta [2026/08/11]
 
 ### Highlights

--- a/src/Yaat.Sim/Commands/GroundCommandHandler.cs
+++ b/src/Yaat.Sim/Commands/GroundCommandHandler.cs
@@ -2057,6 +2057,9 @@ internal static class GroundCommandHandler
         // and advances CurrentIndex past the end, but does not remove the phase entries —
         // truncate the list before adding so Start() lands on the new FollowingPhase at index 0.
         var phases = aircraft.Phases!;
+        // Clear any active ground hold (HOLD/GIVEWAY) so FollowingPhase is not frozen by IsImmobile —
+        // FOLLOWG is a fresh movement clearance, same as TryTaxi/TryAirTaxi which also reset Hold.
+        aircraft.Ground.Hold = null;
         phases.Clear(CommandDispatcher.BuildMinimalContext(aircraft, groundLayout));
         phases.Phases.Clear();
         phases.Phases.Add(new FollowingPhase(follow.TargetCallsign));

--- a/tests/Yaat.Sim.Tests/Simulation/FollowGroundFromParkingTests.cs
+++ b/tests/Yaat.Sim.Tests/Simulation/FollowGroundFromParkingTests.cs
@@ -108,6 +108,64 @@ public class FollowGroundFromParkingTests(ITestOutputHelper output)
         Assert.True(movedNm > 0.02, $"follower barely moved ({movedNm:F3} nm)");
     }
 
+    /// <summary>
+    /// Regression: FOLLOWG must clear any active ground <see cref="AircraftGroundOps.Hold"/> on the
+    /// follower. A taxiing aircraft told HOLD POSITION carries a <c>HoldDirective.HoldPosition</c>
+    /// (auto-released only by RES/TAXI, never on its own). The b13188b FOLLOWG-from-taxiing path
+    /// replaces the phase with <see cref="FollowingPhase"/> but left <c>Ground.Hold</c> set, so
+    /// <c>FollowingPhase.OnTick</c> saw <c>IsImmobile</c> and froze the aircraft at 0 kt forever —
+    /// the command reported success yet the aircraft never followed.
+    /// </summary>
+    [Fact]
+    public void FollowGround_ClearsActiveHold_SoHeldTaxiingFollowerMoves()
+    {
+        if (ReplayToParkedFollower() is not var (engine, _, _))
+        {
+            return;
+        }
+
+        // KPO83 is taxiing; hold it in position (a HoldPosition directive that only RES/TAXI clears).
+        var holdResult = engine.SendCommand("KPO83", "HOLD");
+        Assert.True(holdResult.Success, $"HOLD should succeed but got: {holdResult.Message}");
+        var kpo = engine.FindAircraft("KPO83");
+        Assert.NotNull(kpo);
+        Assert.True(kpo.Ground.IsImmobile, "KPO83 should be immobile after HOLDPOSITION");
+        Assert.IsType<TaxiingPhase>(kpo.Phases?.CurrentPhase);
+
+        // Now tell the held aircraft to follow the (on-ground) leader FTH399.
+        var result = engine.SendCommand("KPO83", "FOLLOWG FTH399");
+        output.WriteLine($"FOLLOWG FTH399 result: success={result.Success} msg={result.Message}");
+        Assert.True(result.Success, $"FOLLOWG should succeed but got: {result.Message}");
+
+        kpo = engine.FindAircraft("KPO83");
+        Assert.NotNull(kpo);
+        Assert.IsType<FollowingPhase>(kpo.Phases?.CurrentPhase);
+
+        // Settle 15 s first so any residual coast from the pre-HOLD taxi speed bleeds off, then
+        // measure sustained movement over the next 45 s. A frozen (still-held) follower produces
+        // ~0 nm here; a real follower keeps taxiing toward the leader.
+        for (int i = 0; i < 15; i++)
+        {
+            engine.TickOneSecond();
+        }
+
+        kpo = engine.FindAircraft("KPO83");
+        Assert.NotNull(kpo);
+        var settledPos = kpo.Position;
+        for (int i = 0; i < 45; i++)
+        {
+            engine.TickOneSecond();
+        }
+
+        kpo = engine.FindAircraft("KPO83");
+        Assert.NotNull(kpo);
+        double movedNm = GeoMath.DistanceNm(settledPos.Lat, settledPos.Lon, kpo.Position.Lat, kpo.Position.Lon);
+        output.WriteLine($"KPO83 phase={kpo.Phases?.CurrentPhase?.Name} sustained-move={movedNm:F3}nm gs={kpo.GroundSpeed:F1}");
+
+        // With the hold left set (the bug) FollowingPhase.OnTick keeps the follower stopped.
+        Assert.True(movedNm > 0.03, $"held follower did not sustain movement ({movedNm:F3} nm) — FOLLOWG did not clear Ground.Hold");
+    }
+
     [Fact]
     public void FTH399_DeferredBehindFollowGroundFromParking()
     {


### PR DESCRIPTION
Fixes #348.

`GroundCommandHandler.TryFollow` swapped in `FollowingPhase` but never cleared `aircraft.Ground.Hold`. A follower carrying an active hold (e.g. `HOLD` while taxiing, or a `GIVEWAY`) then froze at 0 kt, because `FollowingPhase.OnTick` short-circuits on `Ground.IsImmobile` (`Hold is not null`). The `FollowGround`-from-taxiing path was newly enabled by `b13188b`, so this shipped in that commit.

**Fix:** reset `Ground.Hold` in `TryFollow` before starting `FollowingPhase`, mirroring `TryTaxi`/`TryAirTaxi`.

**Self-verifying:** includes a repro test (`FollowGround_ClearsActiveHold_SoHeldTaxiingFollowerMoves`) that holds KPO83 in position while taxiing (real S2-OAK-P recording), issues `FOLLOWG`, and asserts sustained movement. It fails on `main` (`sustained-move=0.000nm`) and passes with this fix. All 96 `FollowGroundFromParkingTests`/`GroundCommandHandlerTests` pass; `Yaat.Sim` builds clean under `-p:TreatWarningsAsErrors=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
