### PR TITLE
fix: closed-traffic approval (MLT/MRT) satisfies the pilot's Landing request (#355)

### DIFF
--- a/src/Yaat.Sim/Pilot/PilotRequestTracker.cs
+++ b/src/Yaat.Sim/Pilot/PilotRequestTracker.cs
@@ -140,7 +140,13 @@ public static class PilotRequestTracker
                 or StopAndGoCommand
                 or LowApproachCommand
                 or ClearedForOptionCommand
-                or GoAroundCommand => PilotPendingRequestResponseState.Satisfied,
+                or GoAroundCommand
+                // "LEFT/RIGHT CLOSED TRAFFIC APPROVED" (7110.65 3-10-11) is the grant for the
+                // "request closed traffic" call PatternEntryPhase records as a Landing request; in
+                // YAAT that is MLT/MRT. Without it the approved pilot re-announces the request every
+                // 120 s (issue #307 class). Mirrors the AirspaceEntry arm below.
+                or MakeLeftTrafficCommand
+                or MakeRightTrafficCommand => PilotPendingRequestResponseState.Satisfied,
                 _ => PilotPendingRequestResponseState.None,
             },
             PilotPendingRequestKind.Approach => command switch

--- a/tests/Yaat.Sim.Tests/Pilot/M104PendingRequestTests.cs
+++ b/tests/Yaat.Sim.Tests/Pilot/M104PendingRequestTests.cs
@@ -77,6 +77,27 @@ public sealed class M104PendingRequestTests
         Assert.Equal(PilotPendingRequestResponseState.Satisfied, ac.PendingPilotRequest!.ResponseState);
     }
 
+    // A VFR pattern aircraft transmits "request closed traffic" (recorded by PatternEntryPhase as a
+    // Landing request). Per 7110.65 3-10-11 the controller grants it with "LEFT/RIGHT CLOSED TRAFFIC
+    // APPROVED" — YAAT's MLT/MRT. That grant must satisfy the request; otherwise the pilot re-announces
+    // "request closed traffic" every 120 s (the issue #307 class). The AirspaceEntry arm already treats
+    // MLT/MRT as satisfying, so the Landing arm omitting them is an asymmetry.
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void MakeTraffic_ClosesPendingClosedTrafficLandingRequest(bool left)
+    {
+        var ac = NewAircraft();
+        ac.IsOnGround = false;
+        PilotRequestTracker.RecordRequest(ac, PilotPendingRequestKind.Landing, nowSeconds: 10, ClosedTrafficLine, PilotRequestContext.None);
+        ParsedCommand makeTraffic = left ? new MakeLeftTrafficCommand(null, null) : new MakeRightTrafficCommand(null, null);
+        var compound = new CompoundCommand([new ParsedBlock(null, [makeTraffic])]);
+
+        PilotRequestTracker.ApplyControllerResponse(ac, compound, nowSeconds: 20);
+
+        Assert.Equal(PilotPendingRequestResponseState.Satisfied, ac.PendingPilotRequest!.ResponseState);
+    }
+
     [Fact]
     public void ClearedForTakeoff_ClosesPendingTakeoffRequest()
     {
@@ -166,6 +187,11 @@ public sealed class M104PendingRequestTests
     private static readonly PilotSpeechText ReadyToTaxiLine = new(
         "ground, ready to taxi.",
         "ground, november one two three alpha bravo, ready to taxi."
+    );
+
+    private static readonly PilotSpeechText ClosedTrafficLine = new(
+        "tower, three miles south at one thousand five hundred, request closed traffic.",
+        "tower, november one two three alpha bravo, three miles south at one thousand five hundred, request closed traffic."
     );
 
     private static readonly PilotSpeechText ReadyForDepartureLine = new(


### PR DESCRIPTION
Fixes #355.

## What
The `Landing` arm of `PilotRequestTracker.ResolveResponse` did not treat `MakeLeftTrafficCommand`/`MakeRightTrafficCommand` (`MLT`/`MRT`) as satisfying. A VFR pattern aircraft's *"request closed traffic"* is recorded as a `Landing` pending request by `PatternEntryPhase`; per 7110.65 §3-10-11 the controller grants it with **"LEFT/RIGHT CLOSED TRAFFIC APPROVED"** — YAAT's `MLT`/`MRT`. Without this mapping the request stayed open and the pilot re-announced *"request closed traffic"* every 120 s (the #307 class of bug). The `AirspaceEntry` arm already treats `MLT`/`MRT` as satisfying; this change mirrors it.

## Change
- `src/Yaat.Sim/Pilot/PilotRequestTracker.cs`: add `MakeLeftTrafficCommand`/`MakeRightTrafficCommand` to the `Landing` → `Satisfied` set.
- `tests/Yaat.Sim.Tests/Pilot/M104PendingRequestTests.cs`: `MakeTraffic_ClosesPendingClosedTrafficLandingRequest` (Theory, left/right) — fails before the fix (`Expected Satisfied / Actual None`), passes after.

## Verification
- `dotnet build src/Yaat.Sim -p:TreatWarningsAsErrors=true` — clean (0 warnings).
- `dotnet test ... --filter "FullyQualifiedName~Pilot|~PatternEntry|~ClosedTraffic"` — 608 passed, 0 failed.

Self-verifying: the repro test is committed alongside the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
