### PR TITLE
fix: HS $spot named like a runway no longer corrupts that runway's crossing (#398)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- A `HS $<spot>` clause whose spot name matches a runway number (e.g. a spot named "9" at an airport with runway 9/27) no longer plants a phantom hold-short on that runway's crossing — the crossing stays a normal runway crossing (auto-crossable), and only the spot itself is held short of. (#398)
+
 ## v0.12.18-beta [2026/08/24]
 
 ### Highlights

--- a/src/Yaat.Sim/Data/Airport/Pathfinding/RouteMaterialiser.cs
+++ b/src/Yaat.Sim/Data/Airport/Pathfinding/RouteMaterialiser.cs
@@ -457,6 +457,15 @@ public static class RouteMaterialiser
     {
         foreach (var target in explicitHoldShorts)
         {
+            // A spot target ($9) is never a runway hold-short. Without this guard its bare number
+            // (the $ sigil is stripped at parse) collides with a runway whose end is that number
+            // (IAH spot "9" vs runway 9/27), mislabeling the crossing ExplicitHoldShort. Mirrors the
+            // IsSpot guards in FindBoundHoldShort and HoldShortAnnotator.TargetMatches.
+            if (target.IsSpot)
+            {
+                continue;
+            }
+
             if (!runwayId.Contains(target.Target))
             {
                 continue;

--- a/tests/Yaat.Sim.Tests/Simulation/Issue398SpotHoldShortRunwayCollisionTests.cs
+++ b/tests/Yaat.Sim.Tests/Simulation/Issue398SpotHoldShortRunwayCollisionTests.cs
@@ -1,0 +1,126 @@
+using Xunit;
+using Xunit.Abstractions;
+using Yaat.Sim.Data.Airport;
+using Yaat.Sim.Tests.Helpers;
+
+namespace Yaat.Sim.Tests.Simulation;
+
+/// <summary>
+/// GitHub issue #398: a <c>HS $spot</c> whose name collides with a runway designator must not corrupt
+/// that runway's crossing on the same route.
+///
+/// <para>
+/// <c>RouteMaterialiser.MatchesExplicitHoldShort</c> tests each explicit hold-short target against a
+/// runway bar with a bare <c>runwayId.Contains(target.Target)</c> — with no <c>IsSpot</c> guard, unlike
+/// its two sibling matchers (<c>FindBoundHoldShort</c> and <c>HoldShortAnnotator.TargetMatches</c>),
+/// which were guarded in the #394 spot-hold-short change. A spot named for a number (the <c>$</c> sigil is
+/// stripped at parse, so <c>HS $9</c> → target <c>"9"</c>) therefore matches a runway whose end is that
+/// number, and the crossing is mislabeled <see cref="HoldShortReason.ExplicitHoldShort"/> instead of
+/// <see cref="HoldShortReason.RunwayCrossing"/>. Consequence: AutoCross (which only auto-clears
+/// RunwayCrossing) leaves the aircraft stopped at a runway the controller never named, and the readback
+/// echoes a phantom "hold short of runway 9".
+/// </para>
+///
+/// <para>
+/// Reproduced on the committed IAH layout, which has an unpaired runway <c>9/27</c> crossed by taxiway
+/// SK and a taxi spot literally named "9". SFO (the #394 fixture) has only L/R-paired runways, so its
+/// numeric spots never collide — which is why the existing tests miss this.
+/// </para>
+/// </summary>
+public class Issue398SpotHoldShortRunwayCollisionTests(ITestOutputHelper output)
+{
+    private static AirportGroundLayout? LoadIah()
+    {
+        TestVnasData.EnsureInitialized();
+        return TestVnasData.NavigationDb is null ? null : new TestAirportGroundData().GetLayout("IAH");
+    }
+
+    [Fact]
+    public void TaxiCrossingRunway9_WithHsSpot9_KeepsRunwayCrossingReason()
+    {
+        var layout = LoadIah();
+        if (layout is null)
+        {
+            return;
+        }
+
+        // The 9/27 hold-short on SK, found by name (ids renumber with geometry).
+        var holdShort = TestLayoutNodes.RunwayHoldShortOnTaxiway(layout, "9", "SK");
+        Assert.NotNull(holdShort);
+
+        // Confirm the collision precondition: the airport really has a spot literally named "9".
+        Assert.NotNull(layout.FindSpotNodeByName("9"));
+
+        // The two SK arms at the bar: one continues across the runway centerline, the other is the
+        // taxiway approach. Start on the approach side and route across so 9/27 is a *crossing*.
+        GroundNode? approachSide = null;
+        GroundNode? runwaySide = null;
+        foreach (var edge in holdShort.Edges)
+        {
+            if (!edge.MatchesTaxiway("SK"))
+            {
+                continue;
+            }
+
+            var neighbor = edge.OtherNode(holdShort);
+            if (neighbor.Edges.Any(e => e.TaxiwayName.Contains("RWY", StringComparison.OrdinalIgnoreCase)))
+            {
+                runwaySide = neighbor;
+            }
+            else
+            {
+                approachSide = neighbor;
+            }
+        }
+
+        Assert.NotNull(approachSide);
+        Assert.NotNull(runwaySide);
+
+        // The SK node on the far side of the runway (a plain SK edge off the runway-side node, not the bar).
+        GroundNode? destAcross = null;
+        foreach (var edge in runwaySide.Edges)
+        {
+            if (!edge.MatchesTaxiway("SK") || edge.TaxiwayName.Contains("RWY", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var neighbor = edge.OtherNode(runwaySide);
+            if (neighbor.Id != holdShort.Id)
+            {
+                destAcross = neighbor;
+            }
+        }
+
+        Assert.NotNull(destAcross);
+
+        TaxiRoute? Resolve(string? holdShortTarget)
+        {
+            var options = new ExplicitPathOptions
+            {
+                ExplicitHoldShorts = holdShortTarget is null ? null : [HoldShortTarget.Parse(holdShortTarget)],
+                DestinationHintNode = destAcross,
+            };
+            var route = TaxiPathfinder.ResolveExplicitPath(layout, approachSide.Id, ["SK"], out string? fail, options, AircraftCategory.Jet);
+            Assert.True(route is not null, $"pathfinder failed: {fail}");
+            return route;
+        }
+
+        HoldShortPoint RunwayPoint(TaxiRoute route) => Assert.Single(route.HoldShortPoints, h => h.NodeId == holdShort.Id);
+
+        // Baseline: a plain crossing (no explicit hold-short) is a RunwayCrossing.
+        var baseline = Resolve(null)!;
+        Assert.Equal(HoldShortReason.RunwayCrossing, RunwayPoint(baseline).Reason);
+
+        // Control: HS $8 — IAH has no runway 8, so the crossing stays a RunwayCrossing.
+        var control = Resolve("$8")!;
+        Assert.Equal(HoldShortReason.RunwayCrossing, RunwayPoint(control).Reason);
+
+        // The bug: HS $9 collides with runway 9's end. The 9/27 crossing must still be a plain
+        // RunwayCrossing (the spot hold-short belongs to the spot node, not this runway bar).
+        var colliding = Resolve("$9")!;
+        var runwayPoint = RunwayPoint(colliding);
+        output.WriteLine($"9/27 crossing with HS $9: reason={runwayPoint.Reason} target={runwayPoint.TargetName}");
+        Assert.Equal(HoldShortReason.RunwayCrossing, runwayPoint.Reason);
+    }
+}


### PR DESCRIPTION
Fixes #398.

## Problem

`RouteMaterialiser.MatchesExplicitHoldShort` (`src/Yaat.Sim/Data/Airport/Pathfinding/RouteMaterialiser.cs`) matched an explicit hold-short **spot** target against a runway bar via a bare `runwayId.Contains(target.Target)`. Because the `$` sigil is stripped at parse, `HS $9` → target `"9"`, which `RunwayIdentifier("9/27").Contains("9")` matches — so a spot named for a runway number corrupts that runway's *crossing* on the same route, mislabeling it `ExplicitHoldShort` instead of `RunwayCrossing`.

Effect: `TaxiRouteAutoCross.Apply` only auto-clears `RunwayCrossing`, so with AutoCross ON the aircraft stops at a runway the controller never named, and the readback echoes a phantom "hold short of runway 9".

The two sibling matchers introduced in the #394 spot change — `FindBoundHoldShort` and `HoldShortAnnotator.TargetMatches` — already guard `IsSpot`; this one was missed.

## Fix

One-line guard: skip spot targets in `MatchesExplicitHoldShort`, mirroring the sibling matchers.

## Test (self-verifying)

`Issue398SpotHoldShortRunwayCollisionTests` runs on the committed IAH layout (unpaired runway `9/27` crossed by taxiway SK + a taxi spot literally named "9" — a real collision that SFO's all-L/R-paired runways can't produce, which is why #394's tests miss it). Node lookups are semantic (not fragile ids). It asserts baseline (no HS) and control (`HS $8`, no runway 8) stay `RunwayCrossing`, and `HS $9` must too — this last assertion **fails on the pre-fix code** (`ExplicitHoldShort`, target `09/27`) and passes with the fix.

## Verification

- `dotnet build src/Yaat.Sim -p:TreatWarningsAsErrors=true` — clean.
- New repro test: fails pre-fix, passes post-fix.
- Full ground-taxi / hold-short / pathfinder sweep (2360 tests) — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
